### PR TITLE
fix: use ErrStageLimitInvalidArg (5107201) for $limit: 0 to match MongoDB 8 (do-l3td)

### DIFF
--- a/internal/handler/common/aggregations/stages/agg_stages_test.go
+++ b/internal/handler/common/aggregations/stages/agg_stages_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stages_test
+
+// Tests for individual aggregation stage parsing and error handling.
+// TestAggStage_* tests verify that stage constructors return the correct
+// error codes and messages to match MongoDB behavior.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dolthub/dongo/internal/handler/common/aggregations/stages"
+	"github.com/dolthub/dongo/internal/handler/handlererrors"
+	"github.com/dolthub/dongo/internal/types"
+	"github.com/dolthub/dongo/internal/util/must"
+)
+
+// TestAggStage_limit_LimitZeroError verifies that $limit: 0 returns error code
+// 5107201 (ErrStageLimitInvalidArg) with message "the limit must be positive",
+// matching MongoDB 8 behavior.
+func TestAggStage_limit_LimitZeroError(t *testing.T) {
+	t.Parallel()
+
+	stageDoc := must.NotFail(types.NewDocument("$limit", int32(0)))
+
+	_, err := stages.NewStage(stageDoc)
+	if err == nil {
+		t.Fatal("expected error for $limit: 0, got nil")
+	}
+
+	var cmdErr *handlererrors.CommandError
+	if !errors.As(err, &cmdErr) {
+		t.Fatalf("expected *handlererrors.CommandError, got %T: %v", err, err)
+	}
+
+	if got, want := cmdErr.Code(), handlererrors.ErrStageLimitInvalidArg; got != want {
+		t.Errorf("error code: got %v (%d), want %v (%d)", got, got, want, want)
+	}
+
+	if got, want := cmdErr.Err().Error(), "the limit must be positive"; got != want {
+		t.Errorf("error message: got %q, want %q", got, want)
+	}
+}

--- a/internal/handler/common/params.go
+++ b/internal/handler/common/params.go
@@ -177,7 +177,7 @@ func GetLimitStageParam(value any) (int64, error) {
 		)
 	case limit == 0:
 		return 0, handlererrors.NewCommandErrorMsgWithArgument(
-			handlererrors.ErrStageLimitZero,
+			handlererrors.ErrStageLimitInvalidArg,
 			"the limit must be positive",
 			"$limit (stage)",
 		)


### PR DESCRIPTION
Fixes do-l3td: $limit: 0 returns wrong error code vs MongoDB 8.

MongoDB 8 returns error code 5107201 for both zero and negative $limit values. Previously Dongo returned 15958 (ErrStageLimitZero) for limit == 0. Changed to ErrStageLimitInvalidArg. Added unit test.

bead: do-l3td