### PR TITLE
docker: align runtime ICU with the release build environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM debian:bookworm-slim AS base
+# Ubuntu 24.04 carries libicu74. The release workflow builds release binaries
+# on ubuntu-24.04 / ubuntu-24.04-arm runners, so this base ships the exact
+# ICU runtime the downloaded binaries are linked against. Aligning here
+# avoids the "libicui18n.so.74: cannot open shared object file" runtime
+# failure that older debian:bookworm-slim (ICU 72) produced.
+FROM ubuntu:24.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -8,23 +13,33 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 
-# We use bookworm since the icu dependency ver. between the base and golang images is the same
-FROM golang:1.26.2-bookworm AS build-from-source
+# Source build runs on the same ubuntu:24.04 base so the binary it produces
+# links against the same ICU as the runtime image, and so the source-build
+# and download-binary paths are interchangeable.
+FROM ubuntu:24.04 AS build-from-source
 ENV DEBIAN_FRONTEND=noninteractive
 ARG DUMBODB_VERSION
+# TARGETARCH is provided automatically by BuildKit/buildx (amd64, arm64, ...).
+ARG TARGETARCH
+ARG GO_VERSION=1.26.2
 
 # COPY doesn't support conditionals, so we rely on the build context maybe having a dumbodb/ directory
 # to distinguish between source and binary builds using DUMBODB_VERSION=source.
 COPY dumbodb*/go.mod* dumbodb*/go.sum* /tmp/dumbodb/
 WORKDIR /tmp/dumbodb/
 
-# Check for source to avoid unnecessary installation of build dependencies
+# Check for source to avoid unnecessary installation of build dependencies.
+# Go is not in ubuntu 24.04's archive at 1.26+; install from the official
+# tarball.
 RUN if [ "$DUMBODB_VERSION" = "source" ]; then \
         cd /tmp/dumbodb || { echo "Make sure the dumbodb/ directory exists in your workspace to build from source."; exit 1; }; \
         apt-get update -y && \
-        apt-get install -y libicu-dev && \
+        apt-get install -y --no-install-recommends ca-certificates curl libicu-dev gcc g++ && \
+        curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+            | tar -xz -C /usr/local && \
         rm -rf /var/lib/apt/lists/*; \
     fi
+ENV PATH=/usr/local/go/bin:$PATH
 
 # Separate layers to avoid redundant downloads
 RUN if [ "$DUMBODB_VERSION" = "source" ]; then \
@@ -61,12 +76,14 @@ RUN if [ "$DUMBODB_VERSION" = "latest" ]; then \
 FROM base AS runtime
 ARG DUMBODB_VERSION
 
-# icu dependency for source builds (transitively required by dolt/vitess)
-RUN if [ "$DUMBODB_VERSION" = "source" ]; then \
-        apt-get update -y && \
-        apt-get install -y --no-install-recommends libicu-dev && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi
+# dumbodb is dynamically linked against ICU (libicui18n / libicuuc /
+# libicudata) via the transitive go-icu-regex CGo binding. Install the
+# runtime-only ICU package unconditionally -- the download-binary path
+# needs it just as much as the source-build path. libicu74 is the
+# matching version on ubuntu:24.04.
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends libicu74 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Only one binary is possible due to DUMBODB_VERSION, so we optionally copy from either stage
 COPY --from=download-binary /usr/local/bin/dumbodb* /usr/local/bin/


### PR DESCRIPTION
The runtime image was failing to start the downloaded binary with

  libicui18n.so.74: cannot open shared object file

because (1) the runtime stage only installed libicu when DUMBODB_VERSION was "source", so the download-binary path landed in an image with no ICU at all, and (2) even with ICU installed, debian:bookworm-slim ships libicu72, while the release binaries are now linked against libicu74 (release.yml builds on ubuntu-24.04 / ubuntu-24.04-arm).

Switch the base image to ubuntu:24.04 so its libicu74 matches the release build environment exactly, and install libicu74 in the runtime unconditionally -- the download-binary path needs it just as much as the source-build path.

The source-build stage also moves to ubuntu:24.04 so the binary it produces links against the same libicu74 the runtime ships. Ubuntu's archive does not carry Go 1.26 yet, so the stage downloads the official Go tarball using TARGETARCH (already wired up for the download-binary stage) to stay multi-arch-correct.

The stale comment about "bookworm icu dependency ver. between the base and golang images is the same" was already misleading once the release workflow stopped building inside golang:bookworm; that comment is now removed.