### PR TITLE
ci: bump JavaScript actions off Node 20 to silence deprecation

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: parity-results
           path: parity-testing/results/

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -99,21 +99,21 @@ jobs:
           done
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push dumbodb image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: .
@@ -124,7 +124,7 @@ jobs:
             DUMBODB_VERSION=${{ steps.inputs.outputs.version }}
 
       - name: Update Docker Hub README
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
GitHub will force JavaScript actions to Node 24 on June 2nd, 2026 and remove Node 20 from runners on September 16th, 2026. Each action below has a Node 24 release ready; bumping the major-version pin picks it up.

push-docker-image.yml:
  docker/login-action            v3 -> v4
  docker/setup-qemu-action       v3 -> v4
  docker/setup-buildx-action     v3 -> v4   (drops deprecated config,
                                             config-inline, install
                                             inputs; we do not use them)
  docker/build-push-action       v6 -> v7
  peter-evans/dockerhub-description v4 -> v5

parity.yml:
  actions/upload-artifact        v6 -> v7

msys2/setup-msys2@v2 and softprops/action-gh-release@v3 already declare node24 in their action.yml so they are not bumped.