### PR TITLE
Show index changes in dumboStatus and dumboDiff

### DIFF
--- a/docs/verify/index-branch-isolation.md
+++ b/docs/verify/index-branch-isolation.md
@@ -57,9 +57,41 @@ After setup, `idxisovdb` has:
 on `idxisovdb@main` or `idxisovdb@nz`.
 
 ```js
-// Create by_name index only on am.
+// Create by_name index only on am (uncommitted -- about to verify
+// that dumboStatus / dumboDiff surface it before the commit).
 var am = db.getSiblingDB("idxisovdb@am")
 am.items.createIndex({ name: 1 }, { name: "by_name" })
+
+// dumboStatus reports the working-set delta. The "modified" status
+// with zero doc changes plus the indexesAdded list tells the user
+// what is about to be committed.
+am.runCommand({ dumboStatus: 1 })
+// Expected: {
+//   branch: "am", dirty: true, readonly: false,
+//   collections: [{
+//     name: "items", status: "modified",
+//     added: 0, modified: 0, deleted: 0,
+//     indexesAdded: [ "by_name" ]
+//   }],
+//   ok: 1
+// }
+
+// dumboDiff shows the full definition of the new index so the user
+// can confirm the keys and options before committing.
+am.runCommand({ dumboDiff: 1 })
+// Expected: {
+//   collections: [{
+//     name: "items", status: "modified",
+//     added: [], removed: [], modified: [],
+//     indexes: [{
+//       name: "by_name", status: "added",
+//       to: { name: "by_name", keys: [{ field: "name", direction: 1 }] }
+//     }]
+//   }],
+//   ok: 1
+// }
+
+// Now commit and verify the index is durable on am only.
 am.runCommand({ doltCommit: 1, message: "am: create by_name", author: "alice <alice@acme.com>" })
 
 // am sees both indexes.
@@ -76,7 +108,9 @@ db.getSiblingDB("idxisovdb@nz").items.getIndexes().map(i => i.name)
 ```
 
 Key checks:
-- `am` lists `["_id_", "by_name"]`
+- `dumboStatus` shows `indexesAdded: ["by_name"]` on `am` before commit
+- `dumboDiff` shows the full `by_name` definition with status `"added"`
+- `am` lists `["_id_", "by_name"]` after commit
 - `main` lists `["_id_"]`
 - `nz` lists `["_id_"]`
 
@@ -274,6 +308,49 @@ Key checks:
 - Per-branch index state survives a server restart
 - Index lookups on non-default branches return correct results after
   restart, with no warmup step (no eager hydration is required)
+
+---
+
+## Scenario 8: dumboDiff shows index modification (drop + recreate with different spec)
+
+Indexes are content-addressed by their full definition, so dropping
+an index and recreating it under the same name with different keys
+appears in `dumboDiff` as a single `"modified"` entry carrying both
+the pre- and post-definition.
+
+```js
+// Fresh database for this scenario -- isolated from idxisovdb above.
+var mdb = db.getSiblingDB("idxmoddb")
+mdb.dropDatabase()
+
+// Seed a collection with an index on field "age" and commit.
+mdb.items.insertOne({ _id: 1, age: 30, name: "alpha" })
+mdb.items.createIndex({ age: 1 }, { name: "by_x" })
+mdb.runCommand({ doltCommit: 1, message: "seed + by_x on age", author: "alice <alice@acme.com>" })
+
+// Drop by_x and recreate it under the same name with a different field.
+mdb.items.dropIndex("by_x")
+mdb.items.createIndex({ name: 1 }, { name: "by_x" })
+
+// dumboStatus shows the index as "changed" (same name, different spec).
+mdb.runCommand({ dumboStatus: 1 })
+// Expected: collections[0].indexesChanged contains "by_x"
+
+// dumboDiff shows a single "modified" entry with both definitions.
+mdb.runCommand({ dumboDiff: 1 })
+// Expected: collections[0].indexes contains one entry:
+//   {
+//     name: "by_x", status: "modified",
+//     from: { name: "by_x", keys: [{ field: "age", direction: 1 }] },
+//     to:   { name: "by_x", keys: [{ field: "name", direction: 1 }] }
+//   }
+```
+
+Key checks:
+- `dumboStatus` lists `by_x` in `indexesChanged` (not `indexesAdded` or
+  `indexesDeleted`).
+- `dumboDiff` returns one index entry with `status: "modified"` and both
+  `from` (old keys) and `to` (new keys) populated.
 
 ---
 

--- a/docs/verify/log.md
+++ b/docs/verify/log.md
@@ -545,7 +545,59 @@ Key checks:
 
 ---
 
-## Scenario 12: stat and patch absent when not requested
+## Scenario 12: stat and patch surface index changes
+
+`stat` lists per-collection index lifecycle (added/changed/deleted) and
+`patch` includes a per-index diff carrying the full definition on each
+side. An index-only commit (no document changes) still appears in both
+outputs.
+
+Run this in a fresh database:
+
+```js
+var idb = db.getSiblingDB("logidxvdb")
+idb.dropDatabase()
+
+idb.items.insertOne({ _id: 1, age: 30, name: "alpha" })
+idb.runCommand({ doltCommit: 1, message: "seed", author: "alice <alice@acme.com>" })
+
+// Index-only commit: no documents change, by_age is added.
+idb.items.createIndex({ age: 1 }, { name: "by_age" })
+idb.runCommand({ doltCommit: 1, message: "add by_age", author: "alice <alice@acme.com>" })
+
+// stat shows indexesAdded on the head commit.
+idb.runCommand({ doltLog: 1, limit: 1, stat: true })
+// Expected: commits[0].stat[0] = {
+//   name: "items", status: "modified",
+//   added: 0, modified: 0, deleted: 0,
+//   indexesAdded: [ "by_age" ]
+// }
+
+// patch shows the full index definition.
+idb.runCommand({ doltLog: 1, limit: 1, patch: true })
+// Expected: commits[0].diff[0].indexes = [{
+//   name: "by_age", status: "added",
+//   to: { name: "by_age", keys: [{ field: "age", direction: 1 }] }
+// }]
+```
+
+Key checks:
+- `stat[0].indexesAdded` contains `"by_age"` even though `added/modified/
+  deleted` are all `0`.
+- `diff[0].indexes` is present with one entry: status `"added"`, no
+  `from`, `to` carries the full IndexInfo (name, keys with direction).
+- The commit is NOT silently dropped from `diff`; before this fix, an
+  index-only commit would not appear in patch output because the
+  document-level diff was empty.
+
+For the drop+recreate-with-different-spec case, `stat` lists the name in
+`indexesChanged` and `patch` shows a single `indexes[]` entry with
+status `"modified"` carrying both `from` and `to` (see
+`index-branch-isolation.md` Scenario 8).
+
+---
+
+## Scenario 13: stat and patch absent when not requested
 
 When neither `stat` nor `patch` is passed, commit entries do not include
 `stat` or `diff` fields.

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -2407,24 +2407,47 @@ func (b *Backend) DumboDBLog(ctx context.Context, params *backends.LogParams) (*
 					status = "modified"
 				}
 
+				// Index lifecycle is content-addressed; the same helper that
+				// powers DumboDBStatus / DumboDBDiff reduces the two DTBLs to
+				// per-index added/deleted/modified.
+				idxDiffs, idxErr := computeIndexDiffs(ctx, db, aHash, bHash)
+				if idxErr != nil {
+					return nil, fmt.Errorf("DumboDBLog: index diffs for %q in commit %q: %w", name, ci.Hash.String(), idxErr)
+				}
+
 				if params.Stat {
 					aMap, _ := collectionMapFromAM(ctx, db, parentAM, name)
 					bMap, _ := collectionMapFromAM(ctx, db, commitAM, name)
 					added, modified, deleted, _ := countCollectionMapDiffs(ctx, aMap, bMap)
-					info.Stat = append(info.Stat, backends.TableStatus{
+					ts := backends.TableStatus{
 						Name: name, Status: status,
 						Added: added, Modified: modified, Deleted: deleted,
-					})
+					}
+					for _, d := range idxDiffs {
+						switch d.Status {
+						case "added":
+							ts.IndexesAdded = append(ts.IndexesAdded, d.Name)
+						case "deleted":
+							ts.IndexesDeleted = append(ts.IndexesDeleted, d.Name)
+						case "modified":
+							ts.IndexesChanged = append(ts.IndexesChanged, d.Name)
+						}
+					}
+					info.Stat = append(info.Stat, ts)
 				}
 
 				if params.Patch {
 					aMap, _ := collectionMapFromAM(ctx, db, parentAM, name)
 					bMap, _ := collectionMapFromAM(ctx, db, commitAM, name)
 					addedDocs, removedDocs, modifiedDocs, _ := diffCollectionMaps(ctx, db.ns, aMap, bMap)
-					if len(addedDocs) > 0 || len(removedDocs) > 0 || len(modifiedDocs) > 0 {
+					// Include the collection's diff entry if any document
+					// OR any index changed. An index-only commit was
+					// silently dropped before this check.
+					if len(addedDocs) > 0 || len(removedDocs) > 0 || len(modifiedDocs) > 0 || len(idxDiffs) > 0 {
 						info.Diff = append(info.Diff, backends.CollectionDiff{
 							Name: name, Status: status,
 							Added: addedDocs, Removed: removedDocs, Modified: modifiedDocs,
+							Indexes: idxDiffs,
 						})
 					}
 				}
@@ -2517,13 +2540,29 @@ func (b *Backend) DumboDBStatus(ctx context.Context, params *backends.Versioning
 			return nil, fmt.Errorf("DumboDBStatus: counting diffs for %q.%q: %w", params.DBName, name, countErr)
 		}
 
-		tables = append(tables, backends.TableStatus{
+		idxDiffs, idxErr := computeIndexDiffs(ctx, state, headHash, workingHash)
+		if idxErr != nil {
+			return nil, fmt.Errorf("DumboDBStatus: computing index diffs for %q.%q: %w", params.DBName, name, idxErr)
+		}
+
+		ts := backends.TableStatus{
 			Name:     name,
 			Status:   status,
 			Added:    addedCount,
 			Modified: modifiedCount,
 			Deleted:  deletedCount,
-		})
+		}
+		for _, d := range idxDiffs {
+			switch d.Status {
+			case "added":
+				ts.IndexesAdded = append(ts.IndexesAdded, d.Name)
+			case "deleted":
+				ts.IndexesDeleted = append(ts.IndexesDeleted, d.Name)
+			case "modified":
+				ts.IndexesChanged = append(ts.IndexesChanged, d.Name)
+			}
+		}
+		tables = append(tables, ts)
 	}
 
 	if tables == nil {
@@ -2772,10 +2811,16 @@ func (b *Backend) DumboDBDiff(ctx context.Context, params *backends.DiffParams) 
 			return nil, fmt.Errorf("DumboDBDiff: diffing collection %q in db %q: %w", name, params.DBName, diffErr)
 		}
 
-		// A "modified" collection with no document-level changes is no diff at all.
-		// "added" and "deleted" collections always surface, even when empty, so the
-		// caller can see the lifecycle event.
-		if status == "modified" && len(added) == 0 && len(removed) == 0 && len(modified) == 0 {
+		idxDiffs, idxErr := computeIndexDiffs(ctx, state, aHash, bHash)
+		if idxErr != nil {
+			return nil, fmt.Errorf("DumboDBDiff: index diffs for %q in db %q: %w", name, params.DBName, idxErr)
+		}
+
+		// A "modified" collection with no document-level changes AND no
+		// index-level changes is no diff at all. "added" and "deleted"
+		// collections always surface, even when empty, so the caller can
+		// see the lifecycle event.
+		if status == "modified" && len(added) == 0 && len(removed) == 0 && len(modified) == 0 && len(idxDiffs) == 0 {
 			continue
 		}
 
@@ -2785,6 +2830,7 @@ func (b *Backend) DumboDBDiff(ctx context.Context, params *backends.DiffParams) 
 			Added:    added,
 			Removed:  removed,
 			Modified: modified,
+			Indexes:  idxDiffs,
 		})
 	}
 

--- a/internal/backends/dolt/index_diff_test.go
+++ b/internal/backends/dolt/index_diff_test.go
@@ -1,0 +1,320 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dolt
+
+// Tests for index-level surfacing in DumboDBStatus and DumboDBDiff.
+// See workspace-gag.
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/dolthub/dumbodb/internal/backends"
+)
+
+// TestStatus_IndexAddedSurfaces: creating an index in the working set
+// surfaces in dumboStatus as IndexesAdded.
+func TestStatus_IndexAddedSurfaces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	insertDoc(t, b, "testdb", "items", mustDoc(t, "_id", int32(1), "age", int32(30)))
+	commitDB(t, b, "testdb", "seed")
+
+	createIndex(t, ctx, collAt(t, b, "testdb", "main", "items"), "by_age", "age")
+
+	res, err := b.DumboDBStatus(ctx, &backends.VersioningStatusParams{DBName: "testdb", Branch: "main"})
+	if err != nil {
+		t.Fatalf("DumboDBStatus: %v", err)
+	}
+	if len(res.Tables) != 1 {
+		t.Fatalf("expected one modified collection, got %d", len(res.Tables))
+	}
+	got := res.Tables[0]
+	if got.Status != "modified" || got.Added != 0 || got.Modified != 0 || got.Deleted != 0 {
+		t.Errorf("expected modified with zero doc changes, got %+v", got)
+	}
+	if !reflect.DeepEqual(got.IndexesAdded, []string{"by_age"}) {
+		t.Errorf("IndexesAdded = %v, want [by_age]", got.IndexesAdded)
+	}
+	if len(got.IndexesChanged) != 0 || len(got.IndexesDeleted) != 0 {
+		t.Errorf("expected no changed/deleted indexes, got changed=%v deleted=%v", got.IndexesChanged, got.IndexesDeleted)
+	}
+}
+
+// TestStatus_IndexDeletedSurfaces: dropping an index in the working set
+// surfaces as IndexesDeleted.
+func TestStatus_IndexDeletedSurfaces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	coll := collAt(t, b, "testdb", "main", "items")
+	insertOne(t, ctx, coll, mustDoc(t, "_id", int32(1), "age", int32(30)))
+	createIndex(t, ctx, coll, "by_age", "age")
+	commitDB(t, b, "testdb", "seed + by_age")
+
+	if _, err := coll.DropIndexes(ctx, &backends.DropIndexesParams{Indexes: []string{"by_age"}}); err != nil {
+		t.Fatalf("DropIndexes: %v", err)
+	}
+
+	res, err := b.DumboDBStatus(ctx, &backends.VersioningStatusParams{DBName: "testdb", Branch: "main"})
+	if err != nil {
+		t.Fatalf("DumboDBStatus: %v", err)
+	}
+	if len(res.Tables) != 1 {
+		t.Fatalf("expected one modified collection, got %d", len(res.Tables))
+	}
+	got := res.Tables[0]
+	if !reflect.DeepEqual(got.IndexesDeleted, []string{"by_age"}) {
+		t.Errorf("IndexesDeleted = %v, want [by_age]", got.IndexesDeleted)
+	}
+}
+
+// TestStatus_IndexChangedSurfaces: drop+recreate with the same name and
+// a different definition surfaces as IndexesChanged. This is the case
+// that disproved "indexes are immutable by name" for diff purposes.
+func TestStatus_IndexChangedSurfaces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	coll := collAt(t, b, "testdb", "main", "items")
+	insertOne(t, ctx, coll, mustDoc(t, "_id", int32(1), "age", int32(30), "name", "alpha"))
+	createIndex(t, ctx, coll, "by_x", "age")
+	commitDB(t, b, "testdb", "seed + by_x on age")
+
+	if _, err := coll.DropIndexes(ctx, &backends.DropIndexesParams{Indexes: []string{"by_x"}}); err != nil {
+		t.Fatalf("DropIndexes: %v", err)
+	}
+	createIndex(t, ctx, coll, "by_x", "name")
+
+	res, err := b.DumboDBStatus(ctx, &backends.VersioningStatusParams{DBName: "testdb", Branch: "main"})
+	if err != nil {
+		t.Fatalf("DumboDBStatus: %v", err)
+	}
+	if len(res.Tables) != 1 {
+		t.Fatalf("expected one modified collection, got %d", len(res.Tables))
+	}
+	got := res.Tables[0]
+	if !reflect.DeepEqual(got.IndexesChanged, []string{"by_x"}) {
+		t.Errorf("IndexesChanged = %v, want [by_x]", got.IndexesChanged)
+	}
+	if len(got.IndexesAdded) != 0 || len(got.IndexesDeleted) != 0 {
+		t.Errorf("expected only IndexesChanged; got added=%v deleted=%v", got.IndexesAdded, got.IndexesDeleted)
+	}
+}
+
+// TestDiff_IndexAddedSurfaces: a create-index-only working set must
+// produce a non-empty diff with the index's full definition.
+func TestDiff_IndexAddedSurfaces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	coll := collAt(t, b, "testdb", "main", "items")
+	insertOne(t, ctx, coll, mustDoc(t, "_id", int32(1), "age", int32(30)))
+	commitDB(t, b, "testdb", "seed")
+
+	createIndex(t, ctx, coll, "by_age", "age")
+
+	res, err := b.DumboDBDiff(ctx, &backends.DiffParams{DBName: "testdb", ConnRootish: "main"})
+	if err != nil {
+		t.Fatalf("DumboDBDiff: %v", err)
+	}
+	if len(res.Collections) != 1 {
+		t.Fatalf("expected one collection in diff, got %d: %+v", len(res.Collections), res.Collections)
+	}
+	got := res.Collections[0]
+	if got.Name != "items" || got.Status != "modified" {
+		t.Errorf("collection = %+v, want name=items status=modified", got)
+	}
+	if len(got.Indexes) != 1 {
+		t.Fatalf("expected one index diff, got %d", len(got.Indexes))
+	}
+	idx := got.Indexes[0]
+	if idx.Name != "by_age" || idx.Status != "added" {
+		t.Errorf("idx diff = %+v, want name=by_age status=added", idx)
+	}
+	if idx.From != nil {
+		t.Errorf("expected From=nil for added, got %+v", idx.From)
+	}
+	if idx.To == nil {
+		t.Fatalf("expected To populated for added")
+	}
+	if idx.To.Name != "by_age" || len(idx.To.Key) != 1 || idx.To.Key[0].Field != "age" {
+		t.Errorf("idx.To = %+v, want by_age on field age", idx.To)
+	}
+}
+
+// TestDiff_IndexChangedShowsBothDefinitions: a same-name drop+recreate
+// with a different spec must surface as a "modified" IndexDiff carrying
+// both From (old spec) and To (new spec).
+func TestDiff_IndexChangedShowsBothDefinitions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	coll := collAt(t, b, "testdb", "main", "items")
+	insertOne(t, ctx, coll, mustDoc(t, "_id", int32(1), "age", int32(30), "name", "alpha"))
+	createIndex(t, ctx, coll, "by_x", "age")
+	commitDB(t, b, "testdb", "seed + by_x on age")
+
+	if _, err := coll.DropIndexes(ctx, &backends.DropIndexesParams{Indexes: []string{"by_x"}}); err != nil {
+		t.Fatalf("DropIndexes: %v", err)
+	}
+	createIndex(t, ctx, coll, "by_x", "name")
+
+	res, err := b.DumboDBDiff(ctx, &backends.DiffParams{DBName: "testdb", ConnRootish: "main"})
+	if err != nil {
+		t.Fatalf("DumboDBDiff: %v", err)
+	}
+	if len(res.Collections) != 1 || len(res.Collections[0].Indexes) != 1 {
+		t.Fatalf("expected one collection with one index diff, got %+v", res.Collections)
+	}
+	idx := res.Collections[0].Indexes[0]
+	if idx.Status != "modified" {
+		t.Errorf("idx.Status = %q, want modified", idx.Status)
+	}
+	if idx.From == nil || idx.To == nil {
+		t.Fatalf("modified diff must include both From and To")
+	}
+	if len(idx.From.Key) != 1 || idx.From.Key[0].Field != "age" {
+		t.Errorf("From key = %+v, want field=age", idx.From.Key)
+	}
+	if len(idx.To.Key) != 1 || idx.To.Key[0].Field != "name" {
+		t.Errorf("To key = %+v, want field=name", idx.To.Key)
+	}
+}
+
+// TestLog_StatAndPatch_IncludeIndexChanges: a commit that only changes
+// indexes must surface in both dumboLog --stat and --patch outputs.
+// Before this fix, the patch filter dropped it because the doc diff
+// was empty.
+func TestLog_StatAndPatch_IncludeIndexChanges(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	coll := collAt(t, b, "testdb", "main", "items")
+	insertOne(t, ctx, coll, mustDoc(t, "_id", int32(1), "age", int32(30), "name", "alpha"))
+	commitDB(t, b, "testdb", "c1: seed")
+
+	// c2: index-only commit. No documents change. by_age added.
+	createIndex(t, ctx, coll, "by_age", "age")
+	commitDB(t, b, "testdb", "c2: add by_age")
+
+	// c3: drop+recreate by_age with a different field. Indexes "modified".
+	if _, err := coll.DropIndexes(ctx, &backends.DropIndexesParams{Indexes: []string{"by_age"}}); err != nil {
+		t.Fatalf("DropIndexes: %v", err)
+	}
+	createIndex(t, ctx, coll, "by_age", "name")
+	commitDB(t, b, "testdb", "c3: by_age now on name")
+
+	res, err := b.DumboDBLog(ctx, &backends.LogParams{
+		DBName: "testdb", Branch: "main", Limit: 3, Stat: true, Patch: true,
+	})
+	if err != nil {
+		t.Fatalf("DumboDBLog: %v", err)
+	}
+	if len(res.Commits) < 3 {
+		t.Fatalf("expected at least 3 commits, got %d", len(res.Commits))
+	}
+
+	// Commits are returned newest-first. res.Commits[0] is c3, [1] is c2.
+	c3 := res.Commits[0]
+	c2 := res.Commits[1]
+
+	// c3: modified by_age.
+	if len(c3.Stat) != 1 {
+		t.Fatalf("c3 stat: expected one collection, got %d", len(c3.Stat))
+	}
+	if !reflect.DeepEqual(c3.Stat[0].IndexesChanged, []string{"by_age"}) {
+		t.Errorf("c3 stat IndexesChanged = %v, want [by_age]", c3.Stat[0].IndexesChanged)
+	}
+	if len(c3.Diff) != 1 || len(c3.Diff[0].Indexes) != 1 {
+		t.Fatalf("c3 diff: expected one collection with one index diff, got %+v", c3.Diff)
+	}
+	if c3.Diff[0].Indexes[0].Status != "modified" || c3.Diff[0].Indexes[0].From == nil || c3.Diff[0].Indexes[0].To == nil {
+		t.Errorf("c3 modified index diff malformed: %+v", c3.Diff[0].Indexes[0])
+	}
+
+	// c2: added by_age. This is the bug fix case -- previously the patch
+	// filter dropped it because addedDocs/removedDocs/modifiedDocs were
+	// all empty.
+	if len(c2.Stat) != 1 || !reflect.DeepEqual(c2.Stat[0].IndexesAdded, []string{"by_age"}) {
+		t.Errorf("c2 stat = %+v, want IndexesAdded=[by_age]", c2.Stat)
+	}
+	if len(c2.Diff) != 1 {
+		t.Fatalf("c2 diff: expected one collection in patch (was dropped before the fix), got %d", len(c2.Diff))
+	}
+	if len(c2.Diff[0].Indexes) != 1 || c2.Diff[0].Indexes[0].Status != "added" {
+		t.Errorf("c2 diff Indexes = %+v, want one entry with status=added", c2.Diff[0].Indexes)
+	}
+	if c2.Diff[0].Indexes[0].To == nil || c2.Diff[0].Indexes[0].To.Name != "by_age" {
+		t.Errorf("c2 diff added entry missing To: %+v", c2.Diff[0].Indexes[0])
+	}
+}
+
+// TestDiff_MultipleIndexChanges: combinations of added, deleted, and
+// modified are all surfaced in stable name order.
+func TestDiff_MultipleIndexChanges(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b := newTestBackend(t)
+
+	coll := collAt(t, b, "testdb", "main", "items")
+	insertOne(t, ctx, coll, mustDoc(t, "_id", int32(1), "age", int32(30), "name", "alpha"))
+	createIndex(t, ctx, coll, "by_age", "age")
+	createIndex(t, ctx, coll, "by_swap", "age")
+	commitDB(t, b, "testdb", "seed + by_age + by_swap")
+
+	// Working-set changes: drop by_age, drop+recreate by_swap with new
+	// field, add by_name.
+	if _, err := coll.DropIndexes(ctx, &backends.DropIndexesParams{Indexes: []string{"by_age", "by_swap"}}); err != nil {
+		t.Fatalf("DropIndexes: %v", err)
+	}
+	createIndex(t, ctx, coll, "by_swap", "name")
+	createIndex(t, ctx, coll, "by_name", "name")
+
+	res, err := b.DumboDBDiff(ctx, &backends.DiffParams{DBName: "testdb", ConnRootish: "main"})
+	if err != nil {
+		t.Fatalf("DumboDBDiff: %v", err)
+	}
+	if len(res.Collections) != 1 {
+		t.Fatalf("expected one collection in diff, got %d", len(res.Collections))
+	}
+	indexes := res.Collections[0].Indexes
+	names := make([]string, len(indexes))
+	statuses := make([]string, len(indexes))
+	for i, idx := range indexes {
+		names[i] = idx.Name
+		statuses[i] = idx.Status
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("index diffs not sorted by name: %v", names)
+	}
+	wantNames := []string{"by_age", "by_name", "by_swap"}
+	wantStatus := []string{"deleted", "added", "modified"}
+	if !reflect.DeepEqual(names, wantNames) {
+		t.Errorf("names = %v, want %v", names, wantNames)
+	}
+	if !reflect.DeepEqual(statuses, wantStatus) {
+		t.Errorf("statuses = %v, want %v", statuses, wantStatus)
+	}
+}

--- a/internal/backends/dolt/index_resolve.go
+++ b/internal/backends/dolt/index_resolve.go
@@ -28,6 +28,7 @@ package dolt
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/dolthub/dolt/go/gen/fb/serial"
@@ -334,6 +335,93 @@ func buildIndexAM(ctx context.Context, state *dbState, infos []backends.IndexInf
 		return prolly.AddressMap{}, fmt.Errorf("buildIndexAM: flush: %w", err)
 	}
 	return newAM, nil
+}
+
+// computeIndexDiffs compares the secondary-index AMs of two DTBL hashes
+// and returns the per-index lifecycle changes. An index is:
+//   - "added"   when only the b side has it,
+//   - "deleted" when only the a side has it,
+//   - "modified" when both sides carry the same name but different
+//                IndexEntry chunk hashes (drop+recreate with a different
+//                spec).
+//
+// Either hash may be the zero hash (collection absent on that side); in
+// that case the index list for that side is empty.
+//
+// Results are sorted by index name. The IndexInfo pointers in From/To
+// are decoded via resolveIndexEntry (memoized).
+func computeIndexDiffs(ctx context.Context, state *dbState, aDTBL, bDTBL hash.Hash) ([]backends.IndexDiff, error) {
+	aAM, err := indexAMForDTBL(ctx, state.cs, state.ns, aDTBL)
+	if err != nil {
+		return nil, fmt.Errorf("computeIndexDiffs: a side: %w", err)
+	}
+	bAM, err := indexAMForDTBL(ctx, state.cs, state.ns, bDTBL)
+	if err != nil {
+		return nil, fmt.Errorf("computeIndexDiffs: b side: %w", err)
+	}
+
+	aEntries := make(map[string]hash.Hash)
+	if err := aAM.IterAll(ctx, func(name string, h hash.Hash) error {
+		aEntries[name] = h
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("computeIndexDiffs: walking a side: %w", err)
+	}
+	bEntries := make(map[string]hash.Hash)
+	if err := bAM.IterAll(ctx, func(name string, h hash.Hash) error {
+		bEntries[name] = h
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("computeIndexDiffs: walking b side: %w", err)
+	}
+
+	allNames := make(map[string]struct{}, len(aEntries)+len(bEntries))
+	for n := range aEntries {
+		allNames[n] = struct{}{}
+	}
+	for n := range bEntries {
+		allNames[n] = struct{}{}
+	}
+	sorted := make([]string, 0, len(allNames))
+	for n := range allNames {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+
+	var out []backends.IndexDiff
+	for _, name := range sorted {
+		aH, inA := aEntries[name]
+		bH, inB := bEntries[name]
+		switch {
+		case !inA && inB:
+			info, err := resolveIndexEntry(ctx, state.ns, bH)
+			if err != nil {
+				return nil, fmt.Errorf("computeIndexDiffs: resolving b entry for %q: %w", name, err)
+			}
+			toCopy := info.info
+			out = append(out, backends.IndexDiff{Name: name, Status: "added", To: &toCopy})
+		case inA && !inB:
+			info, err := resolveIndexEntry(ctx, state.ns, aH)
+			if err != nil {
+				return nil, fmt.Errorf("computeIndexDiffs: resolving a entry for %q: %w", name, err)
+			}
+			fromCopy := info.info
+			out = append(out, backends.IndexDiff{Name: name, Status: "deleted", From: &fromCopy})
+		case aH != bH:
+			aInfo, err := resolveIndexEntry(ctx, state.ns, aH)
+			if err != nil {
+				return nil, fmt.Errorf("computeIndexDiffs: resolving a entry for %q: %w", name, err)
+			}
+			bInfo, err := resolveIndexEntry(ctx, state.ns, bH)
+			if err != nil {
+				return nil, fmt.Errorf("computeIndexDiffs: resolving b entry for %q: %w", name, err)
+			}
+			fromCopy := aInfo.info
+			toCopy := bInfo.info
+			out = append(out, backends.IndexDiff{Name: name, Status: "modified", From: &fromCopy, To: &toCopy})
+		}
+	}
+	return out, nil
 }
 
 // openIndexMap returns a prolly.Map handle for the secondary-index data

--- a/internal/backends/versioning.go
+++ b/internal/backends/versioning.go
@@ -217,6 +217,14 @@ type TableStatus struct {
 	Added    int
 	Modified int
 	Deleted  int
+
+	// Index lifecycle, name-only for the brief view. An index appears in
+	// IndexesChanged when the same name is present on both sides with
+	// different definitions -- i.e. drop+recreate within the uncommitted
+	// working set. Full per-index detail surfaces through DumboDBDiff.
+	IndexesAdded   []string
+	IndexesChanged []string
+	IndexesDeleted []string
 }
 
 type VersioningStatusResult struct {
@@ -259,13 +267,25 @@ type ModifiedDoc struct {
 	Diff []FieldDiff
 }
 
+// IndexDiff represents the change to a single secondary index between two
+// states. Indexes are content-addressed by their full definition, so a
+// "modified" entry means the same name exists on both sides with a
+// different spec -- the index was dropped and recreated.
+type IndexDiff struct {
+	Name   string
+	Status string     // "added", "deleted", or "modified"
+	From   *IndexInfo // pre-state definition; nil when Status == "added"
+	To     *IndexInfo // post-state definition; nil when Status == "deleted"
+}
+
 // CollectionDiff represents the changes to a single collection.
 type CollectionDiff struct {
 	Name     string
-	Status   string            // "added" (only in b), "deleted" (only in a), or "modified" (in both with doc changes)
+	Status   string            // "added" (only in b), "deleted" (only in a), or "modified" (in both with doc or index changes)
 	Added    []*types.Document // full documents added in "b"
 	Removed  []*types.Document // full documents removed from "a"
 	Modified []ModifiedDoc     // documents changed between "a" and "b"
+	Indexes  []IndexDiff       // secondary-index lifecycle between "a" and "b"
 }
 
 // DiffResult represents the result of VersioningBackend.DumboDBDiff method.

--- a/internal/handler/msg_dumbodb_versioning.go
+++ b/internal/handler/msg_dumbodb_versioning.go
@@ -99,45 +99,7 @@ func (h *Handler) MsgDumboDBDiff(connCtx context.Context, msg *wire.OpMsg) (*wir
 	collections := types.MakeArray(len(res.Collections))
 
 	for _, cd := range res.Collections {
-		added := types.MakeArray(len(cd.Added))
-		for _, doc := range cd.Added {
-			added.Append(doc)
-		}
-
-		removed := types.MakeArray(len(cd.Removed))
-		for _, doc := range cd.Removed {
-			removed.Append(doc)
-		}
-
-		modified := types.MakeArray(len(cd.Modified))
-		for _, m := range cd.Modified {
-			diffArray := types.MakeArray(len(m.Diff))
-			for _, fd := range m.Diff {
-				pairs := []any{"type", fd.Type, "path", fd.Path}
-				if fd.Type != "added" {
-					pairs = append(pairs, "from", fd.From)
-				}
-				if fd.Type != "removed" {
-					pairs = append(pairs, "to", fd.To)
-				}
-				diffEntry := must.NotFail(types.NewDocument(pairs...))
-				diffArray.Append(diffEntry)
-			}
-			entry := must.NotFail(types.NewDocument(
-				"_id", m.ID,
-				"diff", diffArray,
-			))
-			modified.Append(entry)
-		}
-
-		collEntry := must.NotFail(types.NewDocument(
-			"name", cd.Name,
-			"status", cd.Status,
-			"added", added,
-			"removed", removed,
-			"modified", modified,
-		))
-		collections.Append(collEntry)
+		collections.Append(collectionDiffToDoc(cd))
 	}
 
 	return documentOpMsg(
@@ -146,6 +108,142 @@ func (h *Handler) MsgDumboDBDiff(connCtx context.Context, msg *wire.OpMsg) (*wir
 			"ok", float64(1),
 		)),
 	)
+}
+
+// tableStatusToDoc renders a backends.TableStatus as a wire document.
+// Shared by MsgDumboDBStatus and the Stat block of MsgDumboDBLog so
+// the two surfaces stay consistent (notably for the index-lifecycle
+// fields).
+func tableStatusToDoc(t backends.TableStatus) *types.Document {
+	pairs := []any{
+		"name", t.Name,
+		"status", t.Status,
+		"added", int32(t.Added),
+		"modified", int32(t.Modified),
+		"deleted", int32(t.Deleted),
+	}
+	if len(t.IndexesAdded) > 0 {
+		arr := types.MakeArray(len(t.IndexesAdded))
+		for _, n := range t.IndexesAdded {
+			arr.Append(n)
+		}
+		pairs = append(pairs, "indexesAdded", arr)
+	}
+	if len(t.IndexesChanged) > 0 {
+		arr := types.MakeArray(len(t.IndexesChanged))
+		for _, n := range t.IndexesChanged {
+			arr.Append(n)
+		}
+		pairs = append(pairs, "indexesChanged", arr)
+	}
+	if len(t.IndexesDeleted) > 0 {
+		arr := types.MakeArray(len(t.IndexesDeleted))
+		for _, n := range t.IndexesDeleted {
+			arr.Append(n)
+		}
+		pairs = append(pairs, "indexesDeleted", arr)
+	}
+	return must.NotFail(types.NewDocument(pairs...))
+}
+
+// collectionDiffToDoc renders a backends.CollectionDiff as a wire
+// document. Shared by MsgDumboDBDiff and the Patch block of
+// MsgDumboDBLog. The added/removed/modified arrays may be empty (for an
+// index-only diff); the indexes array is populated when present.
+func collectionDiffToDoc(cd backends.CollectionDiff) *types.Document {
+	added := types.MakeArray(len(cd.Added))
+	for _, doc := range cd.Added {
+		added.Append(doc)
+	}
+	removed := types.MakeArray(len(cd.Removed))
+	for _, doc := range cd.Removed {
+		removed.Append(doc)
+	}
+	modified := types.MakeArray(len(cd.Modified))
+	for _, m := range cd.Modified {
+		diffArray := types.MakeArray(len(m.Diff))
+		for _, fd := range m.Diff {
+			fdPairs := []any{"type", fd.Type, "path", fd.Path}
+			if fd.Type != "added" {
+				fdPairs = append(fdPairs, "from", fd.From)
+			}
+			if fd.Type != "removed" {
+				fdPairs = append(fdPairs, "to", fd.To)
+			}
+			diffArray.Append(must.NotFail(types.NewDocument(fdPairs...)))
+		}
+		modified.Append(must.NotFail(types.NewDocument(
+			"_id", m.ID,
+			"diff", diffArray,
+		)))
+	}
+	pairs := []any{
+		"name", cd.Name,
+		"status", cd.Status,
+		"added", added,
+		"removed", removed,
+		"modified", modified,
+	}
+	if len(cd.Indexes) > 0 {
+		indexes := types.MakeArray(len(cd.Indexes))
+		for _, idx := range cd.Indexes {
+			idxPairs := []any{
+				"name", idx.Name,
+				"status", idx.Status,
+			}
+			if idx.From != nil {
+				idxPairs = append(idxPairs, "from", indexInfoToDoc(idx.From))
+			}
+			if idx.To != nil {
+				idxPairs = append(idxPairs, "to", indexInfoToDoc(idx.To))
+			}
+			indexes.Append(must.NotFail(types.NewDocument(idxPairs...)))
+		}
+		pairs = append(pairs, "indexes", indexes)
+	}
+	return must.NotFail(types.NewDocument(pairs...))
+}
+
+// indexInfoToDoc renders an IndexInfo as a wire document for dumboDiff
+// output. Includes the keys (name + asc/desc + special-kind flags) and
+// the unique / sparse / partial flags. Omitted fields take their
+// MongoDB defaults.
+func indexInfoToDoc(info *backends.IndexInfo) *types.Document {
+	keys := types.MakeArray(len(info.Key))
+	for _, kp := range info.Key {
+		kpPairs := []any{"field", kp.Field}
+		switch {
+		case kp.Hashed:
+			kpPairs = append(kpPairs, "kind", "hashed")
+		case kp.Text:
+			kpPairs = append(kpPairs, "kind", "text")
+		case kp.Geo2D:
+			kpPairs = append(kpPairs, "kind", "2d")
+		case kp.Geo2DSphere:
+			kpPairs = append(kpPairs, "kind", "2dsphere")
+		default:
+			direction := int32(1)
+			if kp.Descending {
+				direction = -1
+			}
+			kpPairs = append(kpPairs, "direction", direction)
+		}
+		keys.Append(must.NotFail(types.NewDocument(kpPairs...)))
+	}
+	pairs := []any{
+		"name", info.Name,
+		"keys", keys,
+	}
+	if info.Unique {
+		pairs = append(pairs, "unique", true)
+	}
+	if info.Sparse {
+		pairs = append(pairs, "sparse", true)
+	}
+	if info.PartialFilterExpression != nil {
+		pairs = append(pairs, "partialFilterExpression", info.PartialFilterExpression)
+	}
+	return must.NotFail(types.NewDocument(pairs...))
 }
 
 // branchFromDBName parses the real database name and rootish from an encoded db name.
@@ -1052,13 +1150,7 @@ func (h *Handler) MsgDumboDBLog(connCtx context.Context, msg *wire.OpMsg) (*wire
 		if len(c.Stat) > 0 {
 			statArr := types.MakeArray(len(c.Stat))
 			for _, s := range c.Stat {
-				statArr.Append(must.NotFail(types.NewDocument(
-					"name", s.Name,
-					"status", s.Status,
-					"added", int32(s.Added),
-					"modified", int32(s.Modified),
-					"deleted", int32(s.Deleted),
-				)))
+				statArr.Append(tableStatusToDoc(s))
 			}
 			entry.Set("stat", statArr)
 		}
@@ -1066,39 +1158,7 @@ func (h *Handler) MsgDumboDBLog(connCtx context.Context, msg *wire.OpMsg) (*wire
 		if len(c.Diff) > 0 {
 			diffArr := types.MakeArray(len(c.Diff))
 			for _, cd := range c.Diff {
-				addedDocs := types.MakeArray(len(cd.Added))
-				for _, doc := range cd.Added {
-					addedDocs.Append(doc)
-				}
-				removedDocs := types.MakeArray(len(cd.Removed))
-				for _, doc := range cd.Removed {
-					removedDocs.Append(doc)
-				}
-				modifiedDocs := types.MakeArray(len(cd.Modified))
-				for _, m := range cd.Modified {
-					fieldDiffs := types.MakeArray(len(m.Diff))
-					for _, fd := range m.Diff {
-						fdPairs := []any{"type", fd.Type, "path", fd.Path}
-						if fd.Type != "added" {
-							fdPairs = append(fdPairs, "from", fd.From)
-						}
-						if fd.Type != "removed" {
-							fdPairs = append(fdPairs, "to", fd.To)
-						}
-						fieldDiffs.Append(must.NotFail(types.NewDocument(fdPairs...)))
-					}
-					modifiedDocs.Append(must.NotFail(types.NewDocument(
-						"_id", m.ID,
-						"diff", fieldDiffs,
-					)))
-				}
-				diffArr.Append(must.NotFail(types.NewDocument(
-					"name", cd.Name,
-					"status", cd.Status,
-					"added", addedDocs,
-					"removed", removedDocs,
-					"modified", modifiedDocs,
-				)))
+				diffArr.Append(collectionDiffToDoc(cd))
 			}
 			entry.Set("diff", diffArr)
 		}
@@ -1260,14 +1320,7 @@ func (h *Handler) MsgDumboDBStatus(connCtx context.Context, msg *wire.OpMsg) (*w
 	collections := types.MakeArray(len(res.Tables))
 
 	for _, t := range res.Tables {
-		entry := must.NotFail(types.NewDocument(
-			"name", t.Name,
-			"status", t.Status,
-			"added", int32(t.Added),
-			"modified", int32(t.Modified),
-			"deleted", int32(t.Deleted),
-		))
-		collections.Append(entry)
+		collections.Append(tableStatusToDoc(t))
 	}
 
 	statusDoc := must.NotFail(types.NewDocument(

--- a/tests/index_branch_isolation_verify_test.go
+++ b/tests/index_branch_isolation_verify_test.go
@@ -123,6 +123,38 @@ func TestIndexBranchIsolationVerify(t *testing.T) {
 			Options: options.Index().SetName("by_name"),
 		})
 		require.NoError(t, err, "createIndex on am must succeed")
+
+		// Before committing: dumboStatus surfaces the uncommitted
+		// index addition on am.
+		var statusRes bson.M
+		require.NoError(t, amDB.RunCommand(ctx, bson.D{{Key: "dumboStatus", Value: 1}}).Decode(&statusRes),
+			"dumboStatus on am before commit must succeed")
+		statusColls := mustArrayOfMaps(t, statusRes["collections"])
+		require.Len(t, statusColls, 1, "expected one collection in status")
+		assert.Equal(t, "items", statusColls[0]["name"])
+		assert.Equal(t, "modified", statusColls[0]["status"])
+		assert.Equal(t, []string{"by_name"}, mustStringSlice(t, statusColls[0]["indexesAdded"]),
+			"dumboStatus must surface by_name in indexesAdded before the commit")
+
+		// dumboDiff returns the full index definition (keys + direction).
+		var diffRes bson.M
+		require.NoError(t, amDB.RunCommand(ctx, bson.D{{Key: "dumboDiff", Value: int32(1)}}).Decode(&diffRes),
+			"dumboDiff on am before commit must succeed")
+		diffColls := mustArrayOfMaps(t, diffRes["collections"])
+		require.Len(t, diffColls, 1, "expected one collection in diff")
+		diffIndexes := mustArrayOfMaps(t, diffColls[0]["indexes"])
+		require.Len(t, diffIndexes, 1, "expected one index in diff")
+		assert.Equal(t, "by_name", diffIndexes[0]["name"])
+		assert.Equal(t, "added", diffIndexes[0]["status"])
+		// to: must carry the full definition. from: is absent for added.
+		assert.Nil(t, diffIndexes[0]["from"])
+		toDoc := mustMap(t, diffIndexes[0]["to"])
+		assert.Equal(t, "by_name", toDoc["name"])
+		toKeys := mustArrayOfMaps(t, toDoc["keys"])
+		require.Len(t, toKeys, 1, "expected one key field")
+		assert.Equal(t, "name", toKeys[0]["field"])
+		assert.EqualValues(t, 1, toKeys[0]["direction"])
+
 		dumboDBCommit(t, env, dbName+"@am", "am: create by_name", "alice <alice@acme.com>")
 
 		assert.Equal(t, []string{"_id_", "by_name"}, indexNamesOf(t, env, dbName+"@am"))
@@ -243,4 +275,114 @@ func TestIndexBranchIsolationVerify(t *testing.T) {
 		assert.Equal(t, []string{"_id_", "by_id_name"}, indexNamesOf(t, env, dbName+"@nz"))
 		assert.Equal(t, []int32{212}, idsForName(t, env, dbName+"@nz", "zulu"))
 	})
+
+	// ----------------------------------------------------------------------
+	// Scenario 8: dumboDiff shows index modification (drop + recreate with
+	// different spec). Uses a fresh database isolated from idxisovdb.
+	// ----------------------------------------------------------------------
+	t.Run("Scenario8_IndexModifiedShowsBothDefinitions", func(t *testing.T) {
+		modDbName := fmt.Sprintf("idxmodvrfy%d", rand.Int64N(1_000_000))
+		mdb := env.client.Database(modDbName)
+		require.NoError(t, mdb.Drop(ctx))
+
+		items := mdb.Collection("items")
+		_, err := items.InsertOne(ctx, bson.D{
+			{Key: "_id", Value: int32(1)},
+			{Key: "age", Value: int32(30)},
+			{Key: "name", Value: "alpha"},
+		})
+		require.NoError(t, err)
+		_, err = items.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys:    bson.D{{Key: "age", Value: int32(1)}},
+			Options: options.Index().SetName("by_x"),
+		})
+		require.NoError(t, err)
+		dumboDBCommit(t, env, modDbName, "seed + by_x on age", "alice <alice@acme.com>")
+
+		// Drop by_x and recreate it with a different key. Uncommitted.
+		require.NoError(t, items.Indexes().DropOne(ctx, "by_x"))
+		_, err = items.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys:    bson.D{{Key: "name", Value: int32(1)}},
+			Options: options.Index().SetName("by_x"),
+		})
+		require.NoError(t, err)
+
+		// dumboStatus reports the same name in indexesChanged (not added or deleted).
+		var statusRes bson.M
+		require.NoError(t, mdb.RunCommand(ctx, bson.D{{Key: "dumboStatus", Value: 1}}).Decode(&statusRes))
+		statusColls := mustArrayOfMaps(t, statusRes["collections"])
+		require.Len(t, statusColls, 1)
+		assert.Nil(t, statusColls[0]["indexesAdded"], "indexesAdded must be absent")
+		assert.Nil(t, statusColls[0]["indexesDeleted"], "indexesDeleted must be absent")
+		assert.Equal(t, []string{"by_x"}, mustStringSlice(t, statusColls[0]["indexesChanged"]))
+
+		// dumboDiff returns one entry with status "modified" carrying both
+		// from (age) and to (name) definitions.
+		var diffRes bson.M
+		require.NoError(t, mdb.RunCommand(ctx, bson.D{{Key: "dumboDiff", Value: int32(1)}}).Decode(&diffRes))
+		diffColls := mustArrayOfMaps(t, diffRes["collections"])
+		require.Len(t, diffColls, 1)
+		diffIndexes := mustArrayOfMaps(t, diffColls[0]["indexes"])
+		require.Len(t, diffIndexes, 1)
+		assert.Equal(t, "by_x", diffIndexes[0]["name"])
+		assert.Equal(t, "modified", diffIndexes[0]["status"])
+
+		fromDoc := mustMap(t, diffIndexes[0]["from"])
+		fromKeys := mustArrayOfMaps(t, fromDoc["keys"])
+		require.Len(t, fromKeys, 1)
+		assert.Equal(t, "age", fromKeys[0]["field"], "from must reflect the pre-drop key")
+
+		toDoc := mustMap(t, diffIndexes[0]["to"])
+		toKeys := mustArrayOfMaps(t, toDoc["keys"])
+		require.Len(t, toKeys, 1)
+		assert.Equal(t, "name", toKeys[0]["field"], "to must reflect the recreated key")
+	})
+}
+
+// mustArrayOfMaps converts a bson.A into a []bson.M, fataling on a
+// non-array value or non-map element.
+func mustArrayOfMaps(t *testing.T, v interface{}) []bson.M {
+	t.Helper()
+	arr, ok := v.(bson.A)
+	if !ok {
+		t.Fatalf("expected array, got %T: %v", v, v)
+	}
+	out := make([]bson.M, len(arr))
+	for i, el := range arr {
+		m, ok := el.(bson.M)
+		if !ok {
+			t.Fatalf("array element %d: expected map, got %T", i, el)
+		}
+		out[i] = m
+	}
+	return out
+}
+
+// mustMap converts an interface{} into a bson.M, fataling otherwise.
+func mustMap(t *testing.T, v interface{}) bson.M {
+	t.Helper()
+	m, ok := v.(bson.M)
+	if !ok {
+		t.Fatalf("expected map, got %T: %v", v, v)
+	}
+	return m
+}
+
+// mustStringSlice converts a bson.A of strings into []string, fataling
+// otherwise.
+func mustStringSlice(t *testing.T, v interface{}) []string {
+	t.Helper()
+	arr, ok := v.(bson.A)
+	if !ok {
+		t.Fatalf("expected array, got %T: %v", v, v)
+	}
+	out := make([]string, len(arr))
+	for i, el := range arr {
+		s, ok := el.(string)
+		if !ok {
+			t.Fatalf("array element %d: expected string, got %T", i, el)
+		}
+		out[i] = s
+	}
+	return out
 }

--- a/tests/versioning_log_verify_test.go
+++ b/tests/versioning_log_verify_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // logResult holds the decoded top-level response from a dumboDBLog command.
@@ -623,5 +625,76 @@ func TestLogVerify(t *testing.T) {
 		head := commits[0].(bson.M)
 		assert.Nil(t, head["stat"], "stat must be absent when stat flag is not set")
 		assert.Nil(t, head["diff"], "diff must be absent when patch flag is not set")
+	})
+
+	// -------------------------------------------------------------------------
+	// Scenario 14: index-only commit surfaces in both stat and patch
+	// -------------------------------------------------------------------------
+	t.Run("Scenario14_IndexOnlyCommitInStatAndPatch", func(t *testing.T) {
+		idbName := fmt.Sprintf("logidxvrfy%d", rand.Int64N(1_000_000))
+		idb := env.client.Database(idbName)
+		require.NoError(t, idb.Drop(ctx))
+
+		_, err := idb.Collection("items").InsertOne(ctx, bson.D{
+			{Key: "_id", Value: int32(1)},
+			{Key: "age", Value: int32(30)},
+		})
+		require.NoError(t, err)
+		dumboDBCommit(t, env, idbName, "seed", "alice <alice@acme.com>")
+
+		// Index-only commit: no documents change.
+		_, err = idb.Collection("items").Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys:    bson.D{{Key: "age", Value: int32(1)}},
+			Options: options.Index().SetName("by_age"),
+		})
+		require.NoError(t, err)
+		dumboDBCommit(t, env, idbName, "add by_age", "alice <alice@acme.com>")
+
+		var raw bson.M
+		require.NoError(t, idb.RunCommand(ctx, bson.D{
+			{Key: "doltLog", Value: int32(1)},
+			{Key: "limit", Value: int32(1)},
+			{Key: "stat", Value: true},
+			{Key: "patch", Value: true},
+		}).Decode(&raw))
+
+		head := raw["commits"].(bson.A)[0].(bson.M)
+
+		// Stat must reflect the index-only nature: zero doc counts plus
+		// indexesAdded containing by_age.
+		statArr, ok := head["stat"].(bson.A)
+		require.True(t, ok, "stat must be present")
+		require.Len(t, statArr, 1)
+		s := statArr[0].(bson.M)
+		assert.Equal(t, "items", s["name"])
+		assert.EqualValues(t, 0, s["added"])
+		assert.EqualValues(t, 0, s["modified"])
+		assert.EqualValues(t, 0, s["deleted"])
+		idxAdded, ok := s["indexesAdded"].(bson.A)
+		require.True(t, ok, "indexesAdded must surface in stat")
+		require.Len(t, idxAdded, 1)
+		assert.Equal(t, "by_age", idxAdded[0])
+
+		// Patch must include the commit; before the fix it was silently
+		// dropped because the doc-diff was empty.
+		diffArr, ok := head["diff"].(bson.A)
+		require.True(t, ok, "diff must be present")
+		require.Len(t, diffArr, 1, "index-only commit must appear in patch")
+		cd := diffArr[0].(bson.M)
+		indexes, ok := cd["indexes"].(bson.A)
+		require.True(t, ok, "diff[0].indexes must be present")
+		require.Len(t, indexes, 1)
+		idx := indexes[0].(bson.M)
+		assert.Equal(t, "by_age", idx["name"])
+		assert.Equal(t, "added", idx["status"])
+		assert.Nil(t, idx["from"], "no from for added index")
+		to, ok := idx["to"].(bson.M)
+		require.True(t, ok, "to must be present for added index")
+		assert.Equal(t, "by_age", to["name"])
+		toKeys := to["keys"].(bson.A)
+		require.Len(t, toKeys, 1)
+		k := toKeys[0].(bson.M)
+		assert.Equal(t, "age", k["field"])
+		assert.EqualValues(t, 1, k["direction"])
 	})
 }


### PR DESCRIPTION
Previously there was no way to see the index create/delete operations as a matter of `diff`.