### PR TITLE
eradicate the dbState.workingSets[]

### DIFF
--- a/docs/design/branch-ws-singletons.md
+++ b/docs/design/branch-ws-singletons.md
@@ -1,0 +1,372 @@
+# Singleton Per-Branch WorkingSet Entries
+
+**Status:** Design
+**Date:** 2026-05-27
+**Side quest of:** GC integration. Not strictly required to ship GC,
+but `state.workingSets` is guarded by `state.mu`, which makes
+`state.mu` a write chokepoint and forces the qsc.5 flusher to dance
+around races that this redesign eliminates.
+
+## Problem
+
+`dbState.workingSets map[string]*doltdb.WorkingSet` is a per-database
+cache of "the current WorkingSet for this branch" keyed by branch
+name. It is guarded by `dbState.mu`, the same `RWMutex` that guards
+every other mutable field on `dbState`: indexes, secIndexMaps,
+validators, capped state, mergeState, etc.
+
+Three consequences:
+
+1. **`state.mu` is hot.** Every branch's WS read/write contends with
+   every other branch's WS read/write, and with every metadata-cache
+   update. Two writers on independent branches in the same database
+   serialize.
+2. **The map is mutable in shape.** Entries are inserted on first
+   write to a new branch and deleted on branch delete. Lock-holding
+   patterns must protect both the entry's pointer and the map's
+   structure. Today both protections come from the single `state.mu`.
+3. **The qsc.5 flusher races on the entries.** Sessions hold per-
+   session WS snapshots that, when flushed in arbitrary order, can
+   overwrite each other on disk. The qsc.5 fix gates session pushes
+   to in-txn writes only; the flusher then becomes blind to j:false
+   autoCommit writes, which the GC design doc carries as a wrinkle.
+
+## Target Model
+
+Replace `workingSets map[string]*doltdb.WorkingSet` with a singleton-
+per-branch map. Three properties:
+
+1. **Entries are permanent for server lifetime.** The first access to
+   a branch lazily creates an entry. Subsequent accesses reuse the
+   same entry pointer. Branch deletion does NOT remove the entry; it
+   nils the entry's `ws` field. The entry pointer stays stable
+   forever.
+2. **The map RWMutex protects only the map structure.** Once an
+   entry is in the map, reads of "give me the entry pointer for
+   branch X" take only the map's RLock. The slow path (entry
+   creation) is the only writer of the map structure.
+3. **Each entry owns its own RWMutex for the `ws` field.** Reads of
+   the WS pointer take entry.RLock; writes take entry.Lock. Updates
+   to two different branches' WSes never contend.
+
+```go
+type dbState struct {
+    mu sync.RWMutex   // continues to guard non-WS state (indexes,
+                      // secIndexMaps, validators, mergeState, etc.)
+
+    branchWSMu sync.RWMutex            // guards the map STRUCTURE only
+    branchWS   map[string]*branchWS    // singleton entries, never removed
+}
+
+type branchWS struct {
+    mu     sync.RWMutex
+    ws     *doltdb.WorkingSet   // nil until first load; nil after branch delete
+    wsHash hash.Hash             // on-disk hash of ws; the optimistic-lock
+                                 // value for the next UpdateWorkingSet call.
+                                 // Zero when ws is nil.
+}
+```
+
+`wsHash` is load-bearing for two reasons:
+
+1. **`(*doltdb.WorkingSet).HashOf()` only works for WSes loaded from
+   disk.** A WS built in memory via
+   `ws.WithWorkingRoot(rv).WithStagedRoot(rv)` has no chunk-store
+   address yet; `HashOf()` returns an error. Today's
+   `updateWorkingSet` helper sidesteps this by re-resolving from
+   disk every write to get a fresh `prevHash`. With the hash
+   tracked on the entry, the per-write resolve goes away.
+2. **`ddb.UpdateWorkingSet` requires the optimistic-lock hash.** The
+   call signature is `(ctx, wsRef, newWS, prevHash, meta, rsc)`;
+   `prevHash` must match the on-disk WS hash or the update fails
+   with `ErrOptimisticLockFailed`. The entry-tracked `wsHash` is
+   that value.
+
+Concurrently with this, drop autoCommit's interpretation of
+`j:false`. The wire `writeConcern.j` field continues to be parsed
+(other modes may still honor it -- see "j:false" below); in
+autoCommit, the backend treats `SkipDurableSync=true` as `false` and
+every write fsyncs. The deferred flusher goes away because there is
+no unflushed state to drain.
+
+## j:false
+
+`j:false` stays in the wire protocol. What changes is how each
+backend mode interprets it:
+
+| Mode | j:true (default) | j:false |
+|---|---|---|
+| autoCommit | Every write fsyncs. | Treated as j:true. The latency promise is broken, but no client breakage. |
+| Session-iso / explicit-tx | Writes accumulate on the session. Commit fsyncs. | Reserved for future work: skip the commit-time fsync. Today, parsed but unused at commit time. |
+
+So j:false is not removed. It is silently ignored where it was
+previously implemented incorrectly (autoCommit), and reserved for
+future work where it could be implemented correctly (session-iso
+commit). The wire decode path is unchanged.
+
+## Why Singletons (Not RW-locked Map Entries with Deletion)
+
+An earlier sketch had entries that could be inserted and deleted at
+runtime, each with its own lock. That model has three problems the
+singleton model avoids:
+
+- **Branch-delete races.** A writer with a stale entry pointer could
+  write to an entry that's about to be removed from the map. The
+  result is an orphaned struct with no readers. Detecting the race
+  needs a "deleted" tombstone or a re-check after acquiring the
+  entry lock. Singletons eliminate this: the entry stays alive; the
+  pointer is always valid; branch delete just nils the `ws` field.
+- **Map-Lock for first-write-per-branch.** Entry creation requires
+  `branchWSMu.Lock()`. With deletion in the picture, the lock has
+  to handle insert/delete contention. With singletons, the only
+  writer of the map structure is first-touch, which happens once per
+  branch per server lifetime. After warmup, the map is effectively
+  read-only; readers use `branchWSMu.RLock()` (or no lock if the
+  table is a `sync.Map`).
+- **GC visibility ambiguity.** A deleted-then-rewritten branch can
+  have an orphaned entry holding a WS the world has moved on from.
+  Singletons avoid this: deletion sets `ws = nil`, and a subsequent
+  reuse of the branch name finds the existing entry and refills it.
+
+## Helpers
+
+Direct `state.workingSets[branch]` access goes away. Three helpers
+become the entry points:
+
+```go
+// Returns the entry pointer for a branch. Lazily creates it on
+// first call. The pointer is stable for server lifetime.
+func (s *dbState) branchEntry(branch string) *branchWS
+
+// Reads the current WS for a branch. Lazily loads from doltDB if
+// the entry's ws is nil (cold first read OR branch re-created
+// after deletion). The post-load entry has both ws and wsHash
+// populated.
+func (s *dbState) loadBranchWS(ctx context.Context, branch string)
+    (*doltdb.WorkingSet, error)
+
+// Atomic compute-and-swap, persisted to disk. Holds entry.mu.Lock()
+// across the entire read-compute-write-fsync sequence:
+//   1. Load ws + wsHash from entry (lazy-init if first touch).
+//   2. fn computes newWS from current ws.
+//   3. ddb.UpdateWorkingSet(wsRef, newWS, prevHash=entry.wsHash, ...).
+//      Fails with ErrOptimisticLockFailed if disk moved out from
+//      under us (e.g., another process committed). Surfaced as an
+//      error; caller decides whether to retry.
+//   4. On success: entry.ws = newWS; entry.wsHash = newOnDiskHash.
+// Replaces the current `state.mu.Lock(); read workingSets[b]; build
+// newWS; UpdateWorkingSet; workingSets[b] = newWS` pattern.
+func (s *dbState) updateBranchWS(ctx context.Context, branch string,
+    fn func(*doltdb.WorkingSet) (*doltdb.WorkingSet, error)) error
+```
+
+Branch deletion uses `branchEntry(branch).ws = nil; entry.wsHash =
+hash.Hash{}` under the entry's write lock. No `deleteBranchWS`
+helper; no map-level delete.
+
+### Computing the post-write `wsHash`
+
+`ddb.UpdateWorkingSet` does not return the new on-disk hash; it
+writes the WS chunk via `WriteValue` (which has the hash internally)
+and updates the StoreRoot AddressMap pointing at that chunk. To
+refresh `entry.wsHash` post-write, two options:
+
+- **(a) Re-resolve from disk.** After successful UpdateWorkingSet,
+  call `ddb.ResolveWorkingSet(ctx, wsRef)` and `HashOf()` on the
+  result. One extra in-memory round trip per write (the chunk is in
+  NBS memtable, so no disk I/O). Simple and correct.
+- **(b) Expose the new hash from `ddb.UpdateWorkingSet`.** Dolt-side
+  change. Out of scope per the GC epic's "no dolt refactor"
+  decision.
+
+Pick (a). The memtable lookup is in the µs range; for the
+write-heavy paths this is below noise.
+
+## Lock Ordering
+
+```
+state.mu  ->  branchWSMu  ->  branchWS.mu
+```
+
+The map-level RWMutex is taken briefly only at entry creation. After
+the entry is in the map, readers acquire just `branchWS.mu` (R or W).
+`state.mu` is no longer held to protect WS access at all.
+
+## Call-Site Audit
+
+~17 sites in `backend.go` and `helpers.go` reference
+`state.workingSets[branch]`. Mechanical conversion:
+
+| Pattern today | After |
+|---|---|
+| `ws, ok := state.workingSets[branch]` (read) | `ws, err := state.loadBranchWS(ctx, branch)` |
+| `state.workingSets[branch] = newWS` (write) | inside `updateBranchWS`'s `fn` callback |
+| `state.mu.Lock()` + read + compute + write + `state.mu.Unlock()` | `state.updateBranchWS(ctx, branch, fn)` |
+| `delete(state.workingSets, branch)` | `state.branchEntry(branch).mu.Lock(); entry.ws = nil; entry.mu.Unlock()` |
+| `workingSets: map[...]*doltdb.WorkingSet{defaultBranch: mainWS}` (init) | initialize `branchWS` map with one pre-warmed entry for `defaultBranch` |
+| `workingRootViaSession(..., state.workingSets[branch], ...)` | `workingRootViaSession(..., entry-read, ...)` |
+
+The rule for each site: drop `state.mu` where it was held *solely*
+for the WS access. Keep `state.mu` where it also guards metadata
+caches; the WS access is interleaved using the entry lock.
+
+## Deferred Flusher
+
+Removed.
+
+Today's flusher (workspace-qsc.5) exists to drain j:false writes that
+accumulate in memory. With autoCommit treating j:false as j:true,
+every autoCommit write is durable inline. In-txn writes live on the
+session and flush at commit via `dsess.CommitWorkingSet` /
+`DoltCommit`. Nothing accumulates that needs a background drain.
+
+Delete:
+- `Backend.deferredFlushLoop`
+- `Backend.flushAllDirty`
+- `Backend.flusherStop` / `flusherDone` channels
+- `SessionRegistry.ActiveShadows` (introduced for the flusher;
+  audit for other callers before removing)
+
+The qsc.5 race becomes inexpressible: no flusher, no race.
+
+## GC Interaction
+
+The GC design doc carries a wrinkle titled "`state.workingSets[branch]`
+cache" with two options (force-flush at GC start, or include the
+cache in GC roots). After this work the wrinkle changes shape: chunks
+reachable from autoCommit writes ARE on disk (fsynced), so GC's
+disk-ref walk covers them. Chunks reachable from in-txn writes live
+on session `branchState.workingSet` and are covered by
+`sess.VisitGCRoots`. The `branchWS.ws` entry is a cache of the on-disk
+WS for a branch; GC does not need to traverse it because the disk
+ref it mirrors is already in GC's root set.
+
+Edit the GC doc to drop the wrinkle; replace with one line: "The
+on-disk `working_set/heads/<branch>` ref is GC's root for every
+non-in-txn write."
+
+## Wrinkles
+
+### First load under entry lock
+
+`loadBranchWS` on a cold entry needs to call
+`state.doltDB.ResolveWorkingSet(ctx, wsRef)`. That can be slow.
+Holding `entry.mu.Lock()` across it blocks every concurrent
+read/write on that branch.
+
+Pragmatic answer: hold `entry.mu.Lock()` during the load. The cold
+path is rare (first access per branch per server lifetime). After
+the first load, all callers take `entry.mu.RLock()` for reads.
+
+### Re-creating a deleted branch
+
+After `entry.ws = nil` (branch deleted), a later `doltBranch`
+creates a fresh branch with the same name. The next access finds the
+existing entry with `ws == nil` and reloads from disk. Same code
+path as first-time load. Singleton survives the delete/recreate
+cycle naturally.
+
+### Cache staleness across in-txn commits
+
+When session A commits an in-txn write via `dsess.CommitWorkingSet`,
+the on-disk working_set ref advances. The `branchWS.ws` cache on
+dbState is not updated by this path. Session B reading the cache
+sees the pre-commit WS.
+
+Fix: post-commit, the commit path updates the cache. The dumbo
+`commitDirtyBranchesForSession` (called from
+`OnTransactionCommit`) already mirrors the result into
+`state.workingSets[branch]` (see helpers.go). Convert that mirror
+call to use `branchWS.mu`, store both `ws` and a refreshed
+`wsHash` (via the same ResolveWorkingSet+HashOf pattern as
+`updateBranchWS`).
+
+If we miss a mirror site, the cache becomes stale. Readers see an
+old WS; the next `updateBranchWS` on that branch will fail its
+optimistic lock (`entry.wsHash` no longer matches disk), and the
+helper handles that by re-resolving and retrying. So a stale cache
+is self-healing at the cost of one extra round trip on the next
+write -- not a correctness bug.
+
+### `hydrateAllIndexes` at db open
+
+Already reads from disk via `state.doltDB.ResolveWorkingSet`
+(workspace-qsc.1). No change.
+
+### Wire writeConcern parsing
+
+The handler continues to parse writeConcern from the wire request,
+including the `j` field. The decoded `SkipDurableSync` bool is no
+longer used by autoCommit; it is preserved for future
+session-isolation commit-fsync-skip work. Document the autoCommit
+behavior in the dumbodb docs.
+
+## Out of Scope
+
+- **Session-isolation j:false commit-fsync-skip.** Distinct from
+  the cache refactor; tracked separately if pursued.
+- **`state.mu` decomposition for the metadata caches.** Workspace-i0u
+  is the right home for moving the index / validator / capped caches
+  off dbState; not in scope here.
+- **`ResolveWorkingSet` performance work.** Out of scope unless
+  profiling shows it on a hot path post-removal.
+
+## Resolved Decisions
+
+1. **Lock granularity:** one RWMutex per branch entry. The map
+   itself has its own RWMutex, taken only at entry creation
+   (first-touch per branch per server lifetime).
+2. **Entry lifetime:** singleton. Created once on first access;
+   never removed. Branch deletion nils the entry's `ws` field.
+3. **autoCommit j:false:** silently treated as j:true. Wire decode
+   unchanged. Documented. Other modes' interpretation of j:false is
+   future work.
+4. **Deferred flusher:** removed entirely. No 100ms tick, no
+   session walk, no `ActiveShadows`.
+5. **First-load:** under entry write lock; do not optimize the cold
+   path with `sync.Once`.
+
+## Test Coverage
+
+- Concurrent writes on different branches must not contend. Two
+  goroutines on different branches; assert throughput is roughly
+  2x a single-branch baseline (or, more cheaply, instrument
+  `state.mu` contention and assert near-zero on the WS path).
+- Concurrent writes on the same branch serialize correctly via
+  `entry.mu`. Two goroutines on the same branch, last-write-wins,
+  no torn state.
+- Branch delete then re-create: `entry.ws` is nilled, then
+  re-populated on first access to the new branch. Same entry
+  pointer.
+- writeConcern j:false against autoCommit: the wire decode still
+  works; the write still completes; the on-disk ref advances.
+- In-txn commit refreshes the cache: session A commits an in-txn
+  write; session B's next non-txn read sees the new WS.
+
+The session-routed tests added in workspace-qsc.7 stay; the in-txn
+contract is unchanged.
+
+## Migration Order
+
+Four tasks, in this order:
+
+1. **ws-sn.1: Introduce singleton entries + helpers.** Add
+   `branchWS` type, `branchWSMu`, `branchWS` map on `dbState`. Add
+   `branchEntry`, `loadBranchWS`, `updateBranchWS`. Do NOT yet wire
+   to call sites. New code is dead; no behavioral change.
+2. **ws-sn.2: Convert all `state.workingSets` access sites.**
+   Mechanical, ~17 sites. After this commit, `state.workingSets`
+   is unreferenced.
+3. **ws-sn.3: Drop autoCommit j:false interpretation and remove
+   the deferred flusher.** `updateWorkingRoot`'s `skipSync`
+   parameter still exists at the call interface for non-autoCommit
+   modes, but inside `updateWorkingRoot` it is forced to false in
+   autoCommit. `deferredFlushLoop`, `flushAllDirty`, flusher
+   channels deleted. Bats covers j:false against autoCommit.
+4. **ws-sn.4: Delete the `workingSets` field.** Remove the map
+   field on `dbState`, any init code that seeds it, any leftover
+   write sites flagged by the compiler. Update the GC design doc
+   to drop the `state.workingSets[branch]` wrinkle.
+
+Each task: single commit, go tests pass, bats tests pass, parity
+tests pass, strictly additive testing.

--- a/docs/design/dumbodb-gc.md
+++ b/docs/design/dumbodb-gc.md
@@ -227,28 +227,23 @@ about which paths are GC-safe.
 This is the load-bearing wrinkle. It needs a sub-task before the
 runCommand can ship.
 
-### `state.workingSets[branch]` cache
+### Branch WS cache and GC root set
 
-`dbState.workingSets[branch]` carries cross-session unflushed j:false
-writes that haven't reached the working-set ref on disk. GC marks
-roots from on-disk refs and from session `branchState.workingSet`. It
-does NOT consult `dbState.workingSets[branch]`. If a chunk is reachable
-only from that cache (j:false write not yet flushed AND no session has
-it marked dirty), GC would sweep it.
+`dbState.branchWS[branch].ws` is a cache of the on-disk
+`working_set/heads/<branch>` ref (workspace-4xp). Every write goes
+through `updateBranchWS`, which atomically advances the entry's
+`ws`/`wsHash` AND `ddb.UpdateWorkingSet` -> `nbs.Commit` -> journal
+fsync. Disk is always at least as fresh as the cache, never behind.
 
-In practice with the qsc fix, j:false skipSync writes still update
-`state.workingSets[branch]` but do not mark sessions dirty (autoCommit
-gate). So the cache is the only retainer until `deferredFlushLoop`
-drains it.
+Consequence: GC's disk-ref walk covers every chunk reachable from
+the cache automatically; the cache itself does not need to be in
+GC's root set. In-txn writes that have not yet reached disk live
+on `session.branchState.workingSet` and are picked up by
+`sess.VisitGCRoots` -- the standard dsess path.
 
-Two options:
-- (A) Force-flush `state.workingSets` to disk at GC start (before
-  `BeginGC` walks roots). Simple; adds one fsync per dirty branch.
-- (B) Have the GC orchestrator also include `state.workingSets`
-  entries as roots, parallel to the on-disk ref walk.
-
-Pick (A). It collapses the special case at a small fsync cost. (B)
-requires `DoltDB.GC` to accept additional roots, which it doesn't.
+No special handling at GC start. The runCommand simply calls
+`ddb.GC`; the safepoint controller stalls in-flight writes; the
+root walk is complete.
 
 ### Cursor state and long-lived reads
 

--- a/docs/design/dumbodb-gc.md
+++ b/docs/design/dumbodb-gc.md
@@ -1,0 +1,348 @@
+# DumboDB Garbage Collection
+
+**Status:** Design
+**Date:** 2026-05-27
+**Depends on:** workspace-qsc (closed) -- session-routed writes are the
+prerequisite for `VisitGCRoots` to see in-flight chunks.
+
+## Problem
+
+DumboDB persists every write as a new chunk in dolt's `GenerationalNBS`
+chunk store. Chunks accumulate; nothing reclaims unreachable ones.
+
+dolt already implements the sweep: `doltdb.DoltDB.GC(ctx, gcConfig,
+safepoint)` enumerates branch / remote / internal refs as roots, walks
+them, and asks the chunk store to drop everything else. The safepoint
+controller coordinates with in-flight readers so chunks are not pulled
+out from under them.
+
+What's missing on the dumbo side: an entry point that calls `DoltDB.GC`
+with a safepoint controller appropriate for dumbo's session model. That
+is what this epic adds.
+
+## Target Model
+
+A new `dumboGC` runCommand triggers GC on demand. The command:
+
+1. Routes through `Shadow.Commit` like any durable runCommand, so it
+   participates in the lifecycle bracketing every other command uses.
+2. Acts on the runCommand's target database -- the database the client
+   chose with `getSiblingDB("name")` or its connection URI.
+3. Resolves the wire database name to a single underlying `DoltDB` via
+   the existing `SplitRevisionDbName` path. `mydb@feature` and
+   `mydb@main` resolve to the same `DoltDB` (one chunk store per
+   logical database, holding every branch's chunks). GC sweeps that
+   store; every branch in it is in scope.
+4. Constructs a session-aware safepoint controller and calls
+   `state.doltDB.GC(ctx, gcConfig, sc)`.
+5. Returns a single-database report (sizes before/after, duration).
+
+No auto-GC. No kill-connections fallback. No dolt-side refactor. Each
+of those is reconsidered separately if and when the manual command
+proves insufficient.
+
+## Wire Surface
+
+```
+db.runCommand({
+  dumboGC: 1,
+  mode: "default" | "full" // optional; default: "default"
+})
+```
+
+- `dumboGC: 1` triggers a default-mode GC on the database the command
+  is invoked against. The `1` is a placeholder argument, matching the
+  dolt convention used by other dumbo version-control commands
+  (`dumboCommit: 1`, `doltBranch: 1`).
+- The target database is implicit: whatever `db.runCommand(...)` is
+  scoped to via `getSiblingDB("name")` or the connection URI. Branch
+  selectors in the wire name (`mydb@feature`) resolve to the same
+  underlying `DoltDB` as the base name (`mydb`), so it does not matter
+  which branch-qualified handle the client uses.
+- `mode: "full"` maps to `chunks.GCMode_Full` (rewrite every chunk,
+  including old-gen). `mode: "default"` maps to `chunks.GCMode_Default`
+  (only sweep new-gen / unreferenced old-gen). `mode` is the only knob
+  exposed in v1; `archive` / `incremental-file-size` (dolt's other
+  GC parameters) stay at their defaults.
+
+Response shape:
+
+```
+{
+  ok: 1,
+  db: "test",
+  mode: "default",
+  durationMs: 1234,
+  sizeBefore: 9876543,
+  sizeAfter: 5432109,
+  chunksBefore: 12345,
+  chunksAfter: 6789
+}
+```
+
+`db` echoes the resolved base database name (stripped of any branch
+selector). `chunksBefore`/`chunksAfter` are the chunk-store object
+counts before/after the sweep -- separate from byte sizes because a
+full-mode GC can shrink chunk count without shrinking bytes (and vice
+versa for `default` mode that just unlinks new-gen chunks). On failure
+the response is `{ ok: 0, errmsg: "...", code: <n> }` per the standard
+wire-error convention.
+
+## Safepoint Controller
+
+Mirrors `dprocedures.sessionAwareSafepointController` (the dolt
+session-aware variant), implemented inside the dumbo backend:
+
+```go
+// internal/backends/dolt/gc.go
+type sessionAwareSafepoint struct {
+    controller   *gcctx.GCSafepointController
+    callSession  *dsess.DoltSession
+    doltDB       *doltdb.DoltDB
+    waiter       *gcctx.GCSafepointWaiter
+    keeper       func(hash.Hash) bool
+    dbname       string
+}
+
+func (sc *sessionAwareSafepoint) BeginGC(ctx context.Context, keeper func(hash.Hash) bool) error {
+    sc.doltDB.PurgeCaches()
+    sc.keeper = keeper
+    if err := sc.callSession.VisitGCRoots(ctx, sc.dbname, keeper); err != nil {
+        return err
+    }
+    sc.waiter = sc.controller.Waiter(ctx, sc.callSession, func(ctx context.Context, s gcctx.GCRootsProvider) error {
+        return s.VisitGCRoots(ctx, sc.dbname, sc.keeper)
+    })
+    return nil
+}
+
+func (sc *sessionAwareSafepoint) EstablishPreFinalizeSafepoint(ctx context.Context) error {
+    return sc.waiter.Wait(ctx)
+}
+
+func (sc *sessionAwareSafepoint) EstablishPostFinalizeSafepoint(ctx context.Context) error {
+    return nil
+}
+
+func (sc *sessionAwareSafepoint) CancelSafepoint() {
+    canceled, cancel := context.WithCancel(context.Background())
+    cancel()
+    sc.waiter.Wait(canceled)
+}
+```
+
+This is ~30 lines and copies dolt's structure. Copy is preferred over
+extracting from `dprocedures` because:
+
+- The implementation is small and stable.
+- Extracting requires moving `sessionAwareSafepointController` out of a
+  package that imports the SQL engine; the right home would be a new
+  package under `doltcore/doltdb/gcctx` or `doltcore/dsess`, and that's
+  a non-trivial cross-cutting change.
+- Each dumbo runCommand path has slightly different lifecycle
+  requirements (e.g., dumbo does not have `dSess.SetTransaction(nil)`
+  after GC the way `dprocedures` does); copying lets us adapt rather
+  than parameterize.
+
+If a future change in dolt's controller is load-bearing for correctness,
+we revisit -- either by syncing the copy or by lifting at that point.
+
+## Orchestration
+
+```go
+// internal/backends/dolt/gc.go
+func (b *Backend) DumboDBGC(ctx context.Context, params *backends.GCParams) (*backends.GCResult, error)
+```
+
+`params.DBName` is the wire-level name as received (possibly carrying
+a branch selector). The orchestrator:
+
+1. Strips any branch selector via `doltdb.SplitRevisionDbName` to get
+   the base name, then resolves it to the backing `*dbState` via
+   `b.lookupDbStateForDsess`. Error if absent.
+2. Pulls the calling session from `ctx` (the same path
+   `pushWSToSession` uses). The session is required; in-process
+   callers without a session error out. GC needs a `GCRootsProvider`
+   to seed `BeginGC`'s root walk.
+3. Snapshots `sizeBefore` and `chunksBefore` from the chunk store
+   (NBS exposes size / chunk-count via `StorageSize()` / equivalents;
+   verify exact method names at implementation time).
+4. Constructs `gcConfig` from `params.Mode`.
+5. Constructs the `sessionAwareSafepoint` controller.
+6. Calls `state.doltDB.GC(ctx, gcConfig, sc)`.
+7. Records `sizeAfter`, `chunksAfter`, and `durationMs`, returns the
+   single-db report.
+
+`state.mu` is NOT held during `DoltDB.GC`. The chunk store has its own
+locking for GC; holding `state.mu` would block every concurrent write
+on that database for the full GC duration, which can be seconds.
+Concurrent writes during GC are handled by the safepoint -- writes
+quiesce briefly at the pre-finalize boundary.
+
+## Wrinkles
+
+### The `dumboGC` command itself sits inside `Shadow.Commit`
+
+`Shadow.Commit` brackets every durable runCommand with
+`sess.CommandBegin()` / `sess.CommandEnd()`. Those calls register the
+session as "in-flight" with `GCSafepointController`, and
+`waiter.Wait(ctx)` would block until the session is quiesced. The
+running GC command would deadlock waiting for itself.
+
+dolt avoids this in `dprocedures.RunDoltGC` by passing `callSession`
+into the safepoint controller and treating it specially: the controller
+visits `callSession` synchronously in `BeginGC` (already in the snippet
+above) and skips it during the wait phase. `gcctx.Waiter` takes the
+`thisSession` argument exactly to exclude it.
+
+So the deadlock is avoided as long as we plumb `callSession` correctly
+into both `BeginGC`'s direct visit AND `Waiter(ctx, callSession, ...)`.
+Same as dolt; mirror the structure.
+
+### The deferred flusher and capped cleanup
+
+`Backend.deferredFlushLoop` (every 100ms) walks
+`SessionRegistry.ActiveShadows()` and flushes dirty `branchState`s.
+`handler.Handler.cappedCleanup` runs periodic capped-collection
+cleanups that mutate working sets.
+
+Both of these run on goroutines that are NOT bracketed by the keeper.
+They take no `CommandBegin`/`CommandEnd`, so `GCSafepointController`
+does not see them. If GC is in flight while a flush is mid-write,
+chunks the flush has read but not yet committed could be swept.
+
+Fix: bracket these loops with the keeper. Each tick that does work
+must call `b.gcController.SessionCommandBegin(rootsProvider)` /
+`SessionCommandEnd(rootsProvider)` around its work. For the deferred
+flusher, the natural rootsProvider is the per-tick view of session
+state; for capped cleanup, the connection-style ConnInfo it already
+builds.
+
+A simpler alternative is to make these loops idempotent on failure
+and let GC tolerate transient inconsistencies. The keeper bracket is
+the same shape as `Shadow.Use`/`Shadow.Commit` and matches dolt's
+internal pattern; adopting it everywhere is cheaper than reasoning
+about which paths are GC-safe.
+
+This is the load-bearing wrinkle. It needs a sub-task before the
+runCommand can ship.
+
+### `state.workingSets[branch]` cache
+
+`dbState.workingSets[branch]` carries cross-session unflushed j:false
+writes that haven't reached the working-set ref on disk. GC marks
+roots from on-disk refs and from session `branchState.workingSet`. It
+does NOT consult `dbState.workingSets[branch]`. If a chunk is reachable
+only from that cache (j:false write not yet flushed AND no session has
+it marked dirty), GC would sweep it.
+
+In practice with the qsc fix, j:false skipSync writes still update
+`state.workingSets[branch]` but do not mark sessions dirty (autoCommit
+gate). So the cache is the only retainer until `deferredFlushLoop`
+drains it.
+
+Two options:
+- (A) Force-flush `state.workingSets` to disk at GC start (before
+  `BeginGC` walks roots). Simple; adds one fsync per dirty branch.
+- (B) Have the GC orchestrator also include `state.workingSets`
+  entries as roots, parallel to the on-disk ref walk.
+
+Pick (A). It collapses the special case at a small fsync cost. (B)
+requires `DoltDB.GC` to accept additional roots, which it doesn't.
+
+### Cursor state and long-lived reads
+
+A client cursor is backed by reads against the chunk store; the
+underlying chunk pointers are held inside the iterator. If GC sweeps
+mid-cursor-iteration, the next batch fetch fails.
+
+The safepoint controller addresses this: each command (cursor batch
+fetches included) brackets with `CommandBegin`/`CommandEnd`. Between
+`BeginGC` and `EstablishPreFinalizeSafepoint`, the controller waits
+for every in-flight command to end. New `CommandBegin` calls after
+that point block until GC's `PostFinalize`. So a batch fetch either
+completes before the safepoint or waits until GC is done -- no
+mid-read sweep.
+
+Open cursors that are idle between fetches are NOT bracketed; their
+underlying state lives in `internal/clientconn/cursor`. The chunk
+pointers they hold can be invalidated by GC. The mitigations:
+- Cursor batches re-read from the working set / commit they pinned, so
+  chunks reachable from that root are kept. As long as the cursor's
+  root commit is reachable from a branch ref or session, its chunks
+  survive.
+- Cursors against a working set that gets overwritten mid-cursor are
+  already a pre-existing inconsistency window unrelated to GC.
+
+No additional work needed for cursors in v1.
+
+## Out of Scope
+
+- **Auto-GC.** Post-`dumboCommit` hooks, size-based triggers,
+  `AutoGCController` machinery. Reconsidered separately.
+- **Kill-connections safepoint.** Dumbo has no equivalent: severing a
+  Shadow returns `ErrShadowInvalidated`, surfaces as
+  `NoSuchTransaction` (251), and clients lose lsid / cursor state.
+  The cost profile makes the fallback worse than just waiting or
+  failing.
+- **dolt-side refactor.** No `RunGC` extraction. We reuse public dolt
+  APIs (`DoltDB.GC`, `gcctx.GCSafepointController`, public session
+  methods) and copy the ~30-line safepoint controller. Revisited only
+  if a concrete dolt-private API blocks correctness.
+- **Cross-database orphan collection.** Each `*dbState` has its own
+  `DoltDB` with its own NBS; nothing is shared across databases.
+- **Replication / cluster GC coordination.** DumboDB is single-node.
+- **Versioned-metadata caches under workspace-i0u.** Out of scope per
+  the qsc design doc; tracked separately.
+
+## Resolved Decisions
+
+1. **Trigger model:** `dumboGC` runCommand only. No auto-GC.
+2. **Safepoint strategy:** session-aware only. No kill-connections.
+3. **Dolt refactor:** none yet. Copy `sessionAwareSafepointController`
+   verbatim into the dumbo backend. Revisit if dolt evolves the
+   controller in a way that needs syncing.
+4. **Scope:** the runCommand's target database, resolved via the
+   standard `getSiblingDB`/connection-URI path. Branch selectors in the
+   wire name (`mydb@feature`) collapse to the base database; one chunk
+   store per logical database, holding every branch's chunks, and GC
+   sweeps that store.
+5. **Modes:** `default` and `full` exposed; archive / incremental
+   stay at defaults.
+
+## Open Questions for the Implementation
+
+(These are sub-decisions whose right answer becomes obvious during
+implementation; calling them out so they aren't forgotten.)
+
+- **`StorageSize` / chunk-count APIs.** NBS exposes per-store size
+  and chunk count; the exact method names vary between
+  `nbs.GenerationalNBS` and the wrapping interfaces. Pick at
+  implementation time; if either is unavailable, drop the
+  corresponding field rather than fake it.
+- **Capped cleanup and deferred-flush bracketing.** Lands in its own
+  task before the runCommand task -- the runCommand cannot be safe
+  without it.
+
+## Migration Order
+
+The epic decomposes into:
+
+1. **gc.1 -- Keeper-bracket background loops.** Wrap
+   `deferredFlushLoop` and `Handler.cappedCleanup` ticks with
+   `SessionCommandBegin`/`End` so GC's safepoint sees them. No
+   user-visible change.
+2. **gc.2 -- Backend GC method + safepoint controller.** Add
+   `Backend.DumboDBGC` and `sessionAwareSafepoint`. Force-flush
+   `state.workingSets` at GC start. No wire command yet; tested via go
+   tests.
+3. **gc.3 -- Wire command + handler.** Register `dumboGC` in
+   `handler/commands.go`; build `msg_dolt_gc.go` (or `msg_dumbo_gc.go`)
+   that calls `Backend.DumboDBGC`. Bats coverage.
+4. **gc.4 -- Sweep validation parity test.** Insert a workload, drop
+   it, run GC, verify chunk count / store size drops via `dolt sql -q`
+   against the underlying store (same shape as `conflicts_native.bats`
+   teardown).
+
+Each task: single commit, go tests pass, bats tests pass, parity tests
+pass, strictly additive testing.

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -146,6 +146,12 @@ type dbState struct {
 	// current working root; the isolation unit for both writes and reads.
 	workingSets map[string]*doltdb.WorkingSet
 
+	// branchWSMu guards the structure of branchWS (insert only; entries
+	// are never removed). See branch_ws.go for the singleton-per-branch
+	// entry model that replaces workingSets in workspace-4xp.
+	branchWSMu sync.RWMutex
+	branchWS   map[string]*branchWS
+
 	uuids          map[string]string
 	validators     map[string]*collectionValidator
 	capped         map[string]*cappedCollectionMeta
@@ -1072,6 +1078,7 @@ func (b *Backend) getOrOpenDBLocked(ctx context.Context, dbName string, create b
 		doltDB:         doltDB,
 		datasDB:        datasDB,
 		workingSets:    map[string]*doltdb.WorkingSet{defaultBranch: mainWS},
+		branchWS:       make(map[string]*branchWS),
 		uuids:          make(map[string]string),
 		validators:     make(map[string]*collectionValidator),
 		capped:         make(map[string]*cappedCollectionMeta),

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -233,10 +233,11 @@ func (s *dbState) setAM(ctx context.Context, branch string, am prolly.AddressMap
 // pushWSToSession mirrors a side-channel WS update onto the calling
 // session's branchState so VisitGCRoots sees the post-op state.
 //
-// The active-txn gate is load-bearing: deferredFlushLoop walks every
-// dirty session and writes its WS to disk. Without the gate, idle
-// sessions from prior autoCommit writes stay dirty with stale WS
-// pointers and overwrite the latest writer every tick.
+// The active-txn gate prevents idle sessions from accumulating
+// dirty branchStates with stale WS snapshots, a left-over concern
+// from the qsc.5 flusher era. The flusher is gone, but the gate
+// stays: marking idle sessions dirty makes session.Commit / merge
+// paths behave inconsistently for non-txn writes.
 func (s *dbState) pushWSToSession(ctx context.Context, branch string, newWS *doltdb.WorkingSet) {
 	if !dbNameDsessFriendly(s.name) {
 		return
@@ -268,13 +269,6 @@ type Backend struct {
 
 	docLocksMu sync.Mutex
 	docLocks   map[string]*DocLockManager
-
-	// flusherStop is closed by Close to signal the background flusher to
-	// drain any remaining dirty state and exit.
-	flusherStop chan struct{}
-	// flusherDone is closed by the flusher goroutine when it exits, so Close
-	// can wait for the final drain to complete before tearing down dbs.
-	flusherDone chan struct{}
 
 	sweeperStop   chan struct{}
 	sweeperDone   chan struct{}
@@ -397,13 +391,6 @@ func (b *Backend) openDbNames() []string {
 	return out
 }
 
-// deferredFlushInterval is how often the backend drains per-database dirty
-// state from writeConcern j:false / w:0 writes into the dolt working set
-// (and thus through the NBS journal fsync). A short-enough interval keeps
-// the worst-case window of unflushed writes bounded, while still letting
-// many writes amortize over a single fsync.
-const deferredFlushInterval = 100 * time.Millisecond
-
 // parseAuthorString splits a "Name <email>" string into name and email.
 // If the string doesn't contain " <", the whole string is used as both name and email.
 func parseAuthorString(author string) (name, email string) {
@@ -439,8 +426,6 @@ func newBackend(dataDir string, l *slog.Logger, autoCommit, sessionIsolation boo
 		sessionIsolation: sessionIsolation,
 		dbs:              make(map[string]*dbState),
 		docLocks:         make(map[string]*DocLockManager),
-		flusherStop:      make(chan struct{}),
-		flusherDone:      make(chan struct{}),
 		sweeperStop:      make(chan struct{}),
 		sweeperDone:      make(chan struct{}),
 	}
@@ -472,7 +457,6 @@ func newBackend(dataDir string, l *slog.Logger, autoCommit, sessionIsolation boo
 		return nil, fmt.Errorf("initializing admin database: %w", err)
 	}
 
-	go b.deferredFlushLoop()
 	go b.sessionSweepLoop()
 
 	return b, nil
@@ -496,96 +480,7 @@ func (b *Backend) sessionSweepLoop() {
 	}
 }
 
-// deferredFlushLoop coalesces j:false writes by walking SessionRegistry
-// every deferredFlushInterval.
-func (b *Backend) deferredFlushLoop() {
-	defer close(b.flusherDone)
-
-	ticker := time.NewTicker(deferredFlushInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-b.flusherStop:
-			b.flushAllDirty(context.Background())
-			return
-		case <-ticker.C:
-			b.flushAllDirty(context.Background())
-		}
-	}
-}
-
-// flushAllDirty flushes every non-in-txn session's dirty branchStates.
-// Sessions inside an active dsess txn are skipped: their overlays belong
-// to the in-progress txn and are persisted via commit/merge.
-func (b *Backend) flushAllDirty(ctx context.Context) {
-	if b.sessions == nil {
-		return
-	}
-	shadows := b.sessions.ActiveShadows()
-	if len(shadows) == 0 {
-		return
-	}
-
-	b.mu.RLock()
-	dbs := make(map[string]*dbState, len(b.dbs))
-	for name, db := range b.dbs {
-		dbs[name] = db
-	}
-	b.mu.RUnlock()
-
-	for _, shadow := range shadows {
-		sess := shadow.Session()
-		if sess == nil {
-			continue
-		}
-		if sess.GetTransaction() != nil {
-			continue
-		}
-		sqlCtx := sqlctx.Wrap(ctx, sess)
-		for _, qualified := range sess.DirtyBranchRevisions() {
-			base, branch := doltdb.SplitRevisionDbName(qualified)
-			if branch == "" {
-				branch = defaultBranch
-			}
-			db, ok := dbs[base]
-			if !ok {
-				continue
-			}
-			sessState, sok, err := sess.LookupDbState(sqlCtx, qualified)
-			if err != nil || !sok {
-				continue
-			}
-			ws := sessState.WorkingSet()
-			if ws == nil {
-				continue
-			}
-			db.mu.Lock()
-			err = updateWorkingSet(ctx, db.doltDB, ws, branch)
-			db.mu.Unlock()
-			if err != nil {
-				b.l.Warn("deferred flush failed", "db", base, "branch", branch, "err", err)
-			}
-		}
-	}
-}
-
 func (b *Backend) Close() {
-	// Signal the flusher to drain any remaining deferred writes and exit.
-	// Guard against a double close by checking whether it's already closed,
-	// and against tests that bypass NewBackend by skipping if never started.
-	if b.flusherStop != nil {
-		select {
-		case <-b.flusherStop:
-			// already closed
-		default:
-			close(b.flusherStop)
-		}
-		if b.flusherDone != nil {
-			<-b.flusherDone
-		}
-	}
-
 	if b.sweeperStop != nil {
 		select {
 		case <-b.sweeperStop:

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -142,13 +142,9 @@ type dbState struct {
 	doltDB  *doltdb.DoltDB
 	datasDB datas.Database
 
-	// workingSets is the per-branch in-progress state. Each value is the session's
-	// current working root; the isolation unit for both writes and reads.
-	workingSets map[string]*doltdb.WorkingSet
-
 	// branchWSMu guards the structure of branchWS (insert only; entries
-	// are never removed). See branch_ws.go for the singleton-per-branch
-	// entry model that replaces workingSets in workspace-4xp.
+	// are never removed). Each entry has its own RWMutex guarding its
+	// ws and wsHash fields. See branch_ws.go.
 	branchWSMu sync.RWMutex
 	branchWS   map[string]*branchWS
 
@@ -965,7 +961,6 @@ func (b *Backend) getOrOpenDBLocked(ctx context.Context, dbName string, create b
 		vs:             vs,
 		doltDB:         doltDB,
 		datasDB:        datasDB,
-		workingSets:    map[string]*doltdb.WorkingSet{defaultBranch: mainWS},
 		branchWS:       make(map[string]*branchWS),
 		uuids:          make(map[string]string),
 		validators:     make(map[string]*collectionValidator),

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -189,26 +189,23 @@ func (s *dbState) persistAM(ctx context.Context, branch string, workingAM prolly
 	if err != nil {
 		return err
 	}
-	ws, ok := s.workingSets[branch]
-	if !ok {
-		wsRef := doltref.NewWorkingSetRef("heads/" + branch)
-		if loaded, loadErr := s.doltDB.ResolveWorkingSet(ctx, wsRef); loadErr == nil {
-			ws = loaded
-		} else {
-			ws = doltdb.EmptyWorkingSet(wsRef)
-		}
+	var newWS *doltdb.WorkingSet
+	if err := s.updateBranchWS(ctx, branch, func(cur *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+		// Set both working and staged to the same root so dolt sees a
+		// clean working tree (no uncommitted diff). Conflict artifacts
+		// are stored in the DTBL ArtifactMap, not in working/staged.
+		newWS = cur.WithWorkingRoot(rv).WithStagedRoot(rv)
+		return newWS, nil
+	}); err != nil {
+		return err
 	}
-	// Set both working and staged to the same root so dolt sees a clean
-	// working tree (no uncommitted diff). Conflict artifacts are stored in
-	// the DTBL ArtifactMap, not in the working/staged difference.
-	newWS := ws.WithWorkingRoot(rv).WithStagedRoot(rv)
-	s.workingSets[branch] = newWS
 	s.pushWSToSession(ctx, branch, newWS)
-	return updateWorkingSet(ctx, s.doltDB, newWS, branch)
+	return nil
 }
 
 // setAM is a bridge for version-control operations that still produce raw AMs.
-// Wraps the AM in a RootValue and updates the branch working set.
+// Wraps the AM in a RootValue and updates the branch working set in memory only;
+// callers persist via persistAM or a separate updateWorkingSet path.
 // The caller must hold s.mu (write lock).
 func (s *dbState) setAM(ctx context.Context, branch string, am prolly.AddressMap) {
 	rtvlMsg := buildRootValueFlatbuffer(am)
@@ -216,24 +213,20 @@ func (s *dbState) setAM(ctx context.Context, branch string, am prolly.AddressMap
 	if err != nil {
 		return
 	}
-	ws, ok := s.workingSets[branch]
-	if !ok {
-		// New branch not yet cached. Initialize from disk or build a minimal WS.
+	cur, err := s.loadBranchWS(ctx, branch)
+	if err != nil {
+		// Branch may not have an on-disk WS yet (e.g., a freshly
+		// created branch). Build a minimal WS from HEAD.
 		wsRef := doltref.NewWorkingSetRef("heads/" + branch)
-		if loaded, loadErr := s.doltDB.ResolveWorkingSet(ctx, wsRef); loadErr == nil {
-			ws = loaded
-		} else {
-			// No WS on disk yet; staged stays at HEAD.
-			headRV, headErr := headRootValueForBranch(ctx, s, branch)
-			if headErr != nil {
-				headRV = rv
-			}
-			ws = doltdb.EmptyWorkingSet(wsRef).WithStagedRoot(headRV)
+		headRV, headErr := headRootValueForBranch(ctx, s, branch)
+		if headErr != nil {
+			headRV = rv
 		}
+		cur = doltdb.EmptyWorkingSet(wsRef).WithStagedRoot(headRV)
 	}
 	// Only update working root; staged stays where it was (HEAD until explicit stage).
-	newWS := ws.WithWorkingRoot(rv)
-	s.workingSets[branch] = newWS
+	newWS := cur.WithWorkingRoot(rv)
+	s.setBranchWS(branch, newWS)
 	s.pushWSToSession(ctx, branch, newWS)
 }
 
@@ -627,10 +620,10 @@ func (b *Backend) Status(ctx context.Context, params *backends.StatusParams) (*b
 	var totalCollections int64
 
 	for dbName, db := range b.dbs {
-		db.mu.RLock()
-		ws := db.workingSets[defaultBranch]
-		db.mu.RUnlock()
-
+		ws, err := db.loadBranchWS(ctx, defaultBranch)
+		if err != nil {
+			return nil, err
+		}
 		rv, err := workingRootViaSession(ctx, sess, ws, dbName, defaultBranch)
 		if err != nil {
 			return nil, err
@@ -751,10 +744,10 @@ func (b *Backend) ListDatabases(ctx context.Context, params *backends.ListDataba
 				continue
 			}
 
-			state.mu.RLock()
-			ws := state.workingSets[defaultBranch]
-			state.mu.RUnlock()
-
+			ws, wsErr := state.loadBranchWS(ctx, defaultBranch)
+			if wsErr != nil {
+				continue
+			}
 			rv, err := workingRootViaSession(ctx, sessionFromContext(ctx), ws, dbName, defaultBranch)
 			if err != nil {
 				continue
@@ -1382,12 +1375,16 @@ func (b *Backend) DumboDBCommit(ctx context.Context, params *backends.CommitPara
 
 	if branch == defaultBranch {
 		sess := sessionFromContext(ctx)
+		fallbackWS, fbErr := db.loadBranchWS(ctx, defaultBranch)
+		if fbErr != nil {
+			return nil, fmt.Errorf("DumboDBCommit: loading WS for db %q: %w", params.DBName, fbErr)
+		}
 		if !params.AllowEmpty {
 			headAM, err := db.headRootAM(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("DumboDBCommit: reading HEAD AM for db %q: %w", params.DBName, err)
 			}
-			workingRV, rvErr := workingRootViaSession(ctx, sess, db.workingSets[defaultBranch], params.DBName, defaultBranch)
+			workingRV, rvErr := workingRootViaSession(ctx, sess, fallbackWS, params.DBName, defaultBranch)
 			if rvErr != nil {
 				return nil, fmt.Errorf("DumboDBCommit: reading working root for db %q: %w", params.DBName, rvErr)
 			}
@@ -1404,7 +1401,7 @@ func (b *Backend) DumboDBCommit(ctx context.Context, params *backends.CommitPara
 		if dsErr != nil {
 			return nil, fmt.Errorf("DumboDBCommit: resolving main dataset for db %q: %w", params.DBName, dsErr)
 		}
-		workingRV, rvErr := workingRootViaSession(ctx, sess, db.workingSets[defaultBranch], params.DBName, defaultBranch)
+		workingRV, rvErr := workingRootViaSession(ctx, sess, fallbackWS, params.DBName, defaultBranch)
 		if rvErr != nil {
 			return nil, fmt.Errorf("DumboDBCommit: reading working root for db %q: %w", params.DBName, rvErr)
 		}
@@ -1484,8 +1481,8 @@ func (b *Backend) DumboDBCommit(ctx context.Context, params *backends.CommitPara
 		return nil, fmt.Errorf("DumboDBCommit: updating working set for branch %q: %w", branch, err)
 	}
 
-	// Clear the cached branch AM so the next access reloads from the new HEAD.
-	delete(db.workingSets, branch)
+	// Clear the cached branch WS so the next access reloads from the new HEAD.
+	db.clearBranchWS(branch)
 
 	headHash, ok := newDS.MaybeHeadAddr()
 	if !ok {
@@ -1665,8 +1662,8 @@ func dumboDBBranchDelete(ctx context.Context, db *dbState, params *backends.Bran
 		return nil, fmt.Errorf("DumboDBBranch: deleting branch %q: %w", params.Name, err)
 	}
 
-	// Clear any cached branch AM.
-	delete(db.workingSets, params.Name)
+	// Clear any cached branch WS.
+	db.clearBranchWS(params.Name)
 
 	return &backends.BranchResult{Branch: params.Name}, nil
 }
@@ -2680,13 +2677,17 @@ func (b *Backend) DumboDBReset(ctx context.Context, params *backends.ResetParams
 		if stagedErr != nil {
 			return nil, fmt.Errorf("DumboDBReset (soft): building staged root: %w", stagedErr)
 		}
-		ws, wsErr := workingSetViaSession(ctx, sessionFromContext(ctx), db.workingSets[defaultBranch], params.DBName, defaultBranch)
+		fallbackWS, fbErr := db.loadBranchWS(ctx, defaultBranch)
+		if fbErr != nil {
+			return nil, fmt.Errorf("DumboDBReset (soft): loading working set: %w", fbErr)
+		}
+		ws, wsErr := workingSetViaSession(ctx, sessionFromContext(ctx), fallbackWS, params.DBName, defaultBranch)
 		if wsErr != nil {
 			return nil, fmt.Errorf("DumboDBReset (soft): reading working set: %w", wsErr)
 		}
-		newWS := ws.WithStagedRoot(stagedRV)
-		db.workingSets[defaultBranch] = newWS
-		if err := updateWorkingSet(ctx, db.doltDB, newWS, defaultBranch); err != nil {
+		if err := db.updateBranchWS(ctx, defaultBranch, func(_ *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+			return ws.WithStagedRoot(stagedRV), nil
+		}); err != nil {
 			return nil, fmt.Errorf("DumboDBReset: updating working set (soft): %w", err)
 		}
 	}

--- a/internal/backends/dolt/branch_ws.go
+++ b/internal/backends/dolt/branch_ws.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	doltref "github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// branchWS is the singleton entry for one branch's working-set pointer.
+// Entries are lazily created by branchEntry on first access and never
+// removed for the life of the dbState. Branch deletion clears ws and
+// wsHash but leaves the entry in place so a subsequent re-create of
+// the branch name reuses the same entry pointer.
+//
+// wsHash is the on-disk hash of ws -- the optimistic-lock value for
+// the next UpdateWorkingSet call. (*doltdb.WorkingSet).HashOf() only
+// works for WSes loaded from disk; for in-memory WSes built via
+// WithWorkingRoot it returns an error. Tracking the hash explicitly
+// avoids a per-write ResolveWorkingSet round trip just to get prevHash.
+type branchWS struct {
+	mu     sync.RWMutex
+	ws     *doltdb.WorkingSet
+	wsHash hash.Hash
+}
+
+// branchEntry returns the singleton entry for branch, lazily creating
+// it on first call. The returned pointer is stable for the life of
+// the dbState; concurrent callers see the same pointer.
+func (s *dbState) branchEntry(branch string) *branchWS {
+	s.branchWSMu.RLock()
+	e, ok := s.branchWS[branch]
+	s.branchWSMu.RUnlock()
+	if ok {
+		return e
+	}
+
+	s.branchWSMu.Lock()
+	defer s.branchWSMu.Unlock()
+	if e, ok = s.branchWS[branch]; ok {
+		return e
+	}
+	e = &branchWS{}
+	s.branchWS[branch] = e
+	return e
+}
+
+// loadBranchWS returns the cached working set for branch, resolving
+// from disk on first access (or after the entry was cleared by
+// branch deletion). The post-load entry has both ws and wsHash
+// populated, so subsequent reads hit the entry.RLock fast path.
+func (s *dbState) loadBranchWS(ctx context.Context, branch string) (*doltdb.WorkingSet, error) {
+	e := s.branchEntry(branch)
+
+	e.mu.RLock()
+	if e.ws != nil {
+		ws := e.ws
+		e.mu.RUnlock()
+		return ws, nil
+	}
+	e.mu.RUnlock()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.ws != nil {
+		return e.ws, nil
+	}
+
+	wsRef := doltref.NewWorkingSetRef("heads/" + branch)
+	ws, err := s.doltDB.ResolveWorkingSet(ctx, wsRef)
+	if err != nil {
+		return nil, fmt.Errorf("loadBranchWS: resolving %q: %w", branch, err)
+	}
+	h, err := ws.HashOf()
+	if err != nil {
+		return nil, fmt.Errorf("loadBranchWS: hashing %q: %w", branch, err)
+	}
+	e.ws = ws
+	e.wsHash = h
+	return ws, nil
+}
+
+// updateBranchWS atomically reads, mutates, and persists the working
+// set for branch. It holds entry.mu.Lock across the whole sequence so
+// two writers on the same branch serialize.
+//
+// Steps:
+//  1. Lazy-load the entry if cold.
+//  2. fn(currentWS) computes the new WS.
+//  3. ddb.UpdateWorkingSet writes to disk using entry.wsHash as the
+//     optimistic-lock prevHash. Returns ErrOptimisticLockFailed if
+//     disk moved (e.g., another process committed); the caller
+//     decides whether to retry.
+//  4. On success, refresh entry.wsHash by re-resolving from disk
+//     (the WS chunk is in NBS memtable; the round trip is in-memory).
+//
+// fn must not retain references to the WorkingSet pointer it receives
+// beyond its own return; the entry takes ownership of the new WS.
+func (s *dbState) updateBranchWS(
+	ctx context.Context,
+	branch string,
+	fn func(*doltdb.WorkingSet) (*doltdb.WorkingSet, error),
+) error {
+	e := s.branchEntry(branch)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.ws == nil {
+		wsRef := doltref.NewWorkingSetRef("heads/" + branch)
+		ws, err := s.doltDB.ResolveWorkingSet(ctx, wsRef)
+		if err != nil {
+			return fmt.Errorf("updateBranchWS: resolving %q: %w", branch, err)
+		}
+		h, herr := ws.HashOf()
+		if herr != nil {
+			return fmt.Errorf("updateBranchWS: hashing %q: %w", branch, herr)
+		}
+		e.ws = ws
+		e.wsHash = h
+	}
+
+	newWS, err := fn(e.ws)
+	if err != nil {
+		return err
+	}
+	if newWS == nil {
+		return fmt.Errorf("updateBranchWS: fn returned nil WorkingSet for %q", branch)
+	}
+
+	wsRef := doltref.NewWorkingSetRef("heads/" + branch)
+	meta := doltdb.TodoWorkingSetMeta()
+	var rsc doltdb.ReplicationStatusController
+	if err := s.doltDB.UpdateWorkingSet(ctx, wsRef, newWS, e.wsHash, meta, &rsc); err != nil {
+		return fmt.Errorf("updateBranchWS: UpdateWorkingSet for %q: %w", branch, err)
+	}
+
+	// Refresh wsHash from disk so subsequent updates have a fresh
+	// optimistic-lock value. The chunk is in NBS memtable; this is
+	// an in-memory round trip.
+	persisted, err := s.doltDB.ResolveWorkingSet(ctx, wsRef)
+	if err != nil {
+		return fmt.Errorf("updateBranchWS: post-write resolve for %q: %w", branch, err)
+	}
+	newHash, err := persisted.HashOf()
+	if err != nil {
+		return fmt.Errorf("updateBranchWS: post-write hash for %q: %w", branch, err)
+	}
+	e.ws = persisted
+	e.wsHash = newHash
+	return nil
+}

--- a/internal/backends/dolt/branch_ws.go
+++ b/internal/backends/dolt/branch_ws.go
@@ -97,6 +97,55 @@ func (s *dbState) loadBranchWS(ctx context.Context, branch string) (*doltdb.Work
 	return ws, nil
 }
 
+// setBranchWS updates the cached WS for branch without writing to
+// disk. entry.wsHash is unchanged (the on-disk WS has not moved),
+// which keeps it correct for the next updateBranchWS's optimistic
+// lock. Used by version-control flows that update the in-memory
+// cache and persist via a separate path (e.g., the setAM/persistAM
+// split, or merge-conflict staging that updates state in-memory
+// before the saved merge-state JSON drives the disk write).
+func (s *dbState) setBranchWS(branch string, ws *doltdb.WorkingSet) {
+	e := s.branchEntry(branch)
+	e.mu.Lock()
+	e.ws = ws
+	e.mu.Unlock()
+}
+
+// clearBranchWS nils the entry's ws and wsHash. Used by branch
+// deletion; the entry pointer stays in the map so a subsequent
+// recreate of the branch name reuses the same entry (loadBranchWS
+// will resolve from disk into it).
+func (s *dbState) clearBranchWS(branch string) {
+	e := s.branchEntry(branch)
+	e.mu.Lock()
+	e.ws = nil
+	e.wsHash = hash.Hash{}
+	e.mu.Unlock()
+}
+
+// reloadBranchWSFromDisk re-resolves the entry from doltDB. Used
+// when an out-of-band path advanced disk and the cache needs to
+// catch up (e.g., after dsess.CommitWorkingSet mirrors a merged WS
+// onto the session, the dbState cache must follow to keep
+// non-session readers current).
+func (s *dbState) reloadBranchWSFromDisk(ctx context.Context, branch string) error {
+	wsRef := doltref.NewWorkingSetRef("heads/" + branch)
+	ws, err := s.doltDB.ResolveWorkingSet(ctx, wsRef)
+	if err != nil {
+		return fmt.Errorf("reloadBranchWSFromDisk: resolving %q: %w", branch, err)
+	}
+	h, err := ws.HashOf()
+	if err != nil {
+		return fmt.Errorf("reloadBranchWSFromDisk: hashing %q: %w", branch, err)
+	}
+	e := s.branchEntry(branch)
+	e.mu.Lock()
+	e.ws = ws
+	e.wsHash = h
+	e.mu.Unlock()
+	return nil
+}
+
 // updateBranchWS atomically reads, mutates, and persists the working
 // set for branch. It holds entry.mu.Lock across the whole sequence so
 // two writers on the same branch serialize.

--- a/internal/backends/dolt/branch_ws_test.go
+++ b/internal/backends/dolt/branch_ws_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	doltref "github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/store/prolly"
+	dolttypes "github.com/dolthub/dolt/go/store/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDbState(t *testing.T) *dbState {
+	t.Helper()
+	be, err := newBackend(t.TempDir(), slog.New(slog.NewTextHandler(io.Discard, nil)), false, false, 0, 0)
+	require.NoError(t, err)
+	t.Cleanup(be.Close)
+
+	state, err := be.getOrOpenDB(context.Background(), "test", true)
+	require.NoError(t, err)
+	return state
+}
+
+// mutateWS produces a new WorkingSet whose chunk hash differs from
+// the input by replacing its working root with a freshly-built
+// RootValue that holds a unique tagged AddressMap entry. The entry's
+// value points at the database's schema chunk (a known-reachable
+// hash) so the chunk store's dangling-ref check passes. Used by the
+// tests to advance the on-disk WS without exercising the full
+// insert/commit machinery.
+func mutateWS(t *testing.T, state *dbState, cur *doltdb.WorkingSet, tag string) *doltdb.WorkingSet {
+	t.Helper()
+	ctx := context.Background()
+	require.False(t, state.collSchemaHash.IsEmpty(), "test pre-condition: schema chunk must be written")
+	am, err := prolly.NewEmptyAddressMap(state.ns)
+	require.NoError(t, err)
+	ed := am.Editor()
+	require.NoError(t, ed.Add(ctx, "ws-test-"+tag, state.collSchemaHash))
+	am, err = ed.Flush(ctx)
+	require.NoError(t, err)
+	rtvlMsg := buildRootValueFlatbuffer(am)
+	rv, err := doltdb.NewRootValue(ctx, state.doltDB.ValueReadWriter(), state.doltDB.NodeStore(), dolttypes.SerialMessage(rtvlMsg))
+	require.NoError(t, err)
+	return cur.WithWorkingRoot(rv)
+}
+
+// TestBranchEntry_Singleton: the entry pointer returned for a given
+// branch is stable across calls. Concurrent first-touch callers all
+// see the same entry.
+func TestBranchEntry_Singleton(t *testing.T) {
+	state := newTestDbState(t)
+
+	e1 := state.branchEntry("main")
+	e2 := state.branchEntry("main")
+	assert.Same(t, e1, e2, "branchEntry must return the same pointer for the same branch")
+
+	// Different branches get different entries.
+	feat := state.branchEntry("feat")
+	assert.NotSame(t, e1, feat, "different branches must get distinct entries")
+
+	// Concurrent first-touch on a new branch.
+	const goroutines = 16
+	var wg sync.WaitGroup
+	results := make([]*branchWS, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = state.branchEntry("concurrent")
+		}(i)
+	}
+	wg.Wait()
+	for i := 1; i < goroutines; i++ {
+		assert.Same(t, results[0], results[i], "concurrent first-touch must agree on the entry pointer")
+	}
+}
+
+// TestLoadBranchWS_LazyLoad: a cold entry resolves the WS from
+// doltDB on first call; the post-load wsHash matches HashOf of the
+// loaded WS; subsequent calls hit the cached entry.
+func TestLoadBranchWS_LazyLoad(t *testing.T) {
+	ctx := context.Background()
+	state := newTestDbState(t)
+
+	e := state.branchEntry(defaultBranch)
+	e.mu.RLock()
+	require.Nil(t, e.ws, "entry must start cold")
+	e.mu.RUnlock()
+
+	ws1, err := state.loadBranchWS(ctx, defaultBranch)
+	require.NoError(t, err)
+	require.NotNil(t, ws1)
+
+	e.mu.RLock()
+	assert.Same(t, ws1, e.ws, "entry.ws must point at the loaded WS")
+	loadedHash := e.wsHash
+	e.mu.RUnlock()
+
+	directHash, err := ws1.HashOf()
+	require.NoError(t, err)
+	assert.Equal(t, directHash, loadedHash, "entry.wsHash must equal HashOf of the loaded WS")
+
+	ws2, err := state.loadBranchWS(ctx, defaultBranch)
+	require.NoError(t, err)
+	assert.Same(t, ws1, ws2, "second call must hit the cache and return the same WS pointer")
+}
+
+// TestUpdateBranchWS_HappyPath: the callback's newWS is persisted to
+// disk; entry.ws and entry.wsHash are refreshed to the new on-disk
+// values; ResolveWorkingSet reports the new state.
+func TestUpdateBranchWS_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	state := newTestDbState(t)
+
+	// Warm up: load and capture the original hash.
+	ws0, err := state.loadBranchWS(ctx, defaultBranch)
+	require.NoError(t, err)
+	origHash, err := ws0.HashOf()
+	require.NoError(t, err)
+
+	err = state.updateBranchWS(ctx, defaultBranch, func(cur *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+		require.Same(t, ws0, cur, "fn must receive the cached WS")
+		return mutateWS(t, state, cur, "happy-path"), nil
+	})
+	require.NoError(t, err)
+
+	e := state.branchEntry(defaultBranch)
+	e.mu.RLock()
+	newCached := e.ws
+	newHash := e.wsHash
+	e.mu.RUnlock()
+
+	require.NotNil(t, newCached)
+	assert.NotEqual(t, origHash, newHash, "wsHash must advance after a successful update")
+
+	// Disk-side confirmation.
+	wsRef := doltref.NewWorkingSetRef("heads/" + defaultBranch)
+	onDisk, err := state.doltDB.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	onDiskHash, err := onDisk.HashOf()
+	require.NoError(t, err)
+	assert.Equal(t, newHash, onDiskHash, "cached wsHash must match disk after update")
+}
+
+// TestUpdateBranchWS_OptimisticLockFailure: if the on-disk WS moves
+// out from under us between cache warm-up and update, the
+// optimistic-lock check inside ddb.UpdateWorkingSet rejects the
+// write and we surface the error.
+func TestUpdateBranchWS_OptimisticLockFailure(t *testing.T) {
+	ctx := context.Background()
+	state := newTestDbState(t)
+
+	// Warm the entry.
+	_, err := state.loadBranchWS(ctx, defaultBranch)
+	require.NoError(t, err)
+
+	// Race the disk: write a different WS through the legacy helper
+	// so the entry's wsHash is stale.
+	wsRef := doltref.NewWorkingSetRef("heads/" + defaultBranch)
+	current, err := state.doltDB.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	require.NoError(t, updateWorkingSet(ctx, state.doltDB, mutateWS(t, state, current, "race"), defaultBranch))
+
+	// Now updateBranchWS should fail its optimistic-lock check.
+	err = state.updateBranchWS(ctx, defaultBranch, func(cur *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+		return mutateWS(t, state, cur, "loser"), nil
+	})
+	require.Error(t, err, "stale wsHash must surface as an error")
+}
+
+// TestBranchEntry_ConcurrentDifferentBranchesNoContention: writers
+// on distinct branches do not serialize on a shared lock. Measured
+// indirectly by counting how many entry.mu.Lock() calls happen
+// concurrently across goroutines.
+func TestBranchEntry_ConcurrentDifferentBranchesNoContention(t *testing.T) {
+	ctx := context.Background()
+	state := newTestDbState(t)
+
+	// Pre-warm both branches so cold-load doesn't dominate.
+	require.NoError(t, makeBranch(ctx, state, "alpha"))
+	require.NoError(t, makeBranch(ctx, state, "beta"))
+	_, err := state.loadBranchWS(ctx, "alpha")
+	require.NoError(t, err)
+	_, err = state.loadBranchWS(ctx, "beta")
+	require.NoError(t, err)
+
+	const iterations = 50
+	var wg sync.WaitGroup
+	var inFlight, maxInFlight atomic.Int64
+
+	worker := func(branch string) {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			err := state.updateBranchWS(ctx, branch, func(cur *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+				// Brief hold inside the entry lock; instrument peak concurrency.
+				cur2 := inFlight.Add(1)
+				for {
+					prev := maxInFlight.Load()
+					if cur2 <= prev || maxInFlight.CompareAndSwap(prev, cur2) {
+						break
+					}
+				}
+				time.Sleep(time.Millisecond)
+				inFlight.Add(-1)
+				return mutateWS(t, state, cur, fmt.Sprintf("%s-%d", branch, i)), nil
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	wg.Add(2)
+	go worker("alpha")
+	go worker("beta")
+	wg.Wait()
+
+	assert.GreaterOrEqual(t, maxInFlight.Load(), int64(2),
+		"distinct-branch updateBranchWS calls must be able to overlap; saw peak in-flight=%d", maxInFlight.Load())
+}
+
+// makeBranch creates a branch named name from the current HEAD of
+// defaultBranch. Used by the contention test so each branch has an
+// on-disk working_set ref.
+func makeBranch(ctx context.Context, state *dbState, name string) error {
+	// The dolt branch-create path goes through DumboDBBranch on the
+	// backend, but for unit tests we can construct the WS ref directly
+	// off HEAD: ResolveWorkingSet for the default branch, then write
+	// the same WS under the new branch's ref.
+	mainRef := doltref.NewWorkingSetRef("heads/" + defaultBranch)
+	mainWS, err := state.doltDB.ResolveWorkingSet(ctx, mainRef)
+	if err != nil {
+		return err
+	}
+	newRef := doltref.NewWorkingSetRef("heads/" + name)
+	newWS := doltdb.EmptyWorkingSet(newRef).WithWorkingRoot(mainWS.WorkingRoot()).WithStagedRoot(mainWS.StagedRoot())
+	return updateWorkingSet(ctx, state.doltDB, newWS, name)
+}

--- a/internal/backends/dolt/collection.go
+++ b/internal/backends/dolt/collection.go
@@ -1513,8 +1513,11 @@ func (c *collection) InsertAll(ctx context.Context, params *backends.InsertAllPa
 	}
 
 	if c.db.backend.autoCommit {
-		// state.mu write lock held; safe to read state.workingSets directly.
-		workingRV, rvErr := workingRootViaSession(ctx, sessionFromContext(ctx), state.workingSets[c.db.rootish], c.db.name, c.db.rootish)
+		fallbackWS, fbErr := state.loadBranchWS(ctx, c.db.rootish)
+		if fbErr != nil {
+			return nil, fmt.Errorf("auto-commit: loading WS: %w", fbErr)
+		}
+		workingRV, rvErr := workingRootViaSession(ctx, sessionFromContext(ctx), fallbackWS, c.db.name, c.db.rootish)
 		if rvErr != nil {
 			return nil, fmt.Errorf("auto-commit: reading working root: %w", rvErr)
 		}
@@ -1753,8 +1756,11 @@ func (c *collection) UpdateAll(ctx context.Context, params *backends.UpdateAllPa
 	}
 
 	if c.db.backend.autoCommit {
-		// state.mu write lock held; safe to read state.workingSets directly.
-		workingRV, rvErr := workingRootViaSession(ctx, sessionFromContext(ctx), state.workingSets[c.db.rootish], c.db.name, c.db.rootish)
+		fallbackWS, fbErr := state.loadBranchWS(ctx, c.db.rootish)
+		if fbErr != nil {
+			return nil, fmt.Errorf("auto-commit: loading WS: %w", fbErr)
+		}
+		workingRV, rvErr := workingRootViaSession(ctx, sessionFromContext(ctx), fallbackWS, c.db.name, c.db.rootish)
 		if rvErr != nil {
 			return nil, fmt.Errorf("auto-commit: reading working root: %w", rvErr)
 		}
@@ -1913,8 +1919,11 @@ func (c *collection) DeleteAll(ctx context.Context, params *backends.DeleteAllPa
 	}
 
 	if c.db.backend.autoCommit {
-		// state.mu write lock held; safe to read state.workingSets directly.
-		workingRV, rvErr := workingRootViaSession(ctx, sessionFromContext(ctx), state.workingSets[c.db.rootish], c.db.name, c.db.rootish)
+		fallbackWS, fbErr := state.loadBranchWS(ctx, c.db.rootish)
+		if fbErr != nil {
+			return nil, fmt.Errorf("auto-commit: loading WS: %w", fbErr)
+		}
+		workingRV, rvErr := workingRootViaSession(ctx, sessionFromContext(ctx), fallbackWS, c.db.name, c.db.rootish)
 		if rvErr != nil {
 			return nil, fmt.Errorf("auto-commit: reading working root: %w", rvErr)
 		}

--- a/internal/backends/dolt/commit_session_isolation.go
+++ b/internal/backends/dolt/commit_session_isolation.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	doltref "github.com/dolthub/dolt/go/libraries/doltcore/ref"
 
 	"github.com/dolthub/dumbodb/internal/backends"
 	"github.com/dolthub/dumbodb/internal/clientconn/conninfo"
@@ -93,12 +92,13 @@ func (b *Backend) doltCommitSessionIsolation(ctx context.Context, params *backen
 		return nil, fmt.Errorf("DumboDBCommit: merging working set: %w", err)
 	}
 
-	merged, err := db.doltDB.ResolveWorkingSet(ctx, doltref.NewWorkingSetRef("heads/"+branch))
-	if err != nil {
+	if err := db.reloadBranchWSFromDisk(ctx, branch); err != nil {
 		return nil, fmt.Errorf("DumboDBCommit: reloading merged working set for %q: %w", branch, err)
 	}
-
-	db.workingSets[branch] = merged
+	merged, err := db.loadBranchWS(ctx, branch)
+	if err != nil {
+		return nil, fmt.Errorf("DumboDBCommit: loading merged working set for %q: %w", branch, err)
+	}
 
 	mergedAM, err := amFromWorkingRoot(ctx, merged.WorkingRoot(), db.ns)
 	if err != nil {

--- a/internal/backends/dolt/database.go
+++ b/internal/backends/dolt/database.go
@@ -78,14 +78,14 @@ func (db *database) resolveAM(ctx context.Context, state *dbState) (prolly.Addre
 	if ws, ok := txnVisibleWS(ctx, state, db.rootish); ok {
 		return amFromWorkingRoot(ctx, ws.WorkingRoot(), state.ns)
 	}
-	// Only consult the WS cache for known branches; caret/tilde
-	// traversal rootishes ("main^") aren't there and must fall through
-	// to amFromRootish for commit-hash resolution.
-	if _, ok := state.workingSets[db.rootish]; ok {
-		ws, err := latestBranchWS(ctx, state, db.rootish)
-		if err == nil && ws != nil {
-			return amFromWorkingRoot(ctx, ws.WorkingRoot(), state.ns)
-		}
+	// Consult the WS via the singleton entry, but use loadBranchWS
+	// directly rather than latestBranchWS: the latter falls back to
+	// "initialize a WS from HEAD" for branches with no on-disk ref,
+	// which is wrong for caret/tilde traversal rootishes ("main^")
+	// -- those must fall through to amFromRootish for commit-hash
+	// resolution.
+	if ws, err := state.loadBranchWS(ctx, db.rootish); err == nil && ws != nil {
+		return amFromWorkingRoot(ctx, ws.WorkingRoot(), state.ns)
 	}
 	return amFromRootish(ctx, state, db.rootish)
 }

--- a/internal/backends/dolt/helpers.go
+++ b/internal/backends/dolt/helpers.go
@@ -379,22 +379,18 @@ func (state *dbState) getOrInitBranchWS(ctx context.Context, branch string) (*do
 }
 
 func (state *dbState) loadCommittedWS(ctx context.Context, branch string) (*doltdb.WorkingSet, error) {
-	// state.workingSets carries cross-session unflushed j:false writes
-	// that aren't on disk yet; check it before falling back to the ref.
-	if ws, ok := state.workingSets[branch]; ok {
+	if ws, err := state.loadBranchWS(ctx, branch); err == nil {
 		return ws, nil
 	}
+	// No working_set ref on disk yet for this branch; initialize from HEAD
+	// and seed the entry so subsequent reads hit the cache.
 	wsRef := doltref.NewWorkingSetRef("heads/" + branch)
-	ws, err := state.doltDB.ResolveWorkingSet(ctx, wsRef)
-	if err != nil {
-		// Branch has no working set yet; initialize from HEAD.
-		rv, rvErr := headRootValueForBranch(ctx, state, branch)
-		if rvErr != nil {
-			return nil, fmt.Errorf("initializing working set for %q: %w", branch, rvErr)
-		}
-		ws = doltdb.EmptyWorkingSet(wsRef).WithWorkingRoot(rv).WithStagedRoot(rv)
+	rv, rvErr := headRootValueForBranch(ctx, state, branch)
+	if rvErr != nil {
+		return nil, fmt.Errorf("initializing working set for %q: %w", branch, rvErr)
 	}
-	state.workingSets[branch] = ws
+	ws := doltdb.EmptyWorkingSet(wsRef).WithWorkingRoot(rv).WithStagedRoot(rv)
+	state.setBranchWS(branch, ws)
 	return ws, nil
 }
 
@@ -481,7 +477,12 @@ func (state *dbState) commitDirtyBranchesForSession(sqlCtx *sql.Context, sess *d
 		if err := sess.SetWorkingSet(sqlCtx, qualified, merged); err != nil {
 			return branches, fmt.Errorf("commitTransaction: updating sess WS for %q: %w", qualified, err)
 		}
-		state.workingSets[branch] = merged
+		// Refresh the singleton entry so non-session readers see the
+		// merged WS and the next updateBranchWS's optimistic lock uses
+		// the post-merge wsHash.
+		if err := state.reloadBranchWSFromDisk(sqlCtx, branch); err != nil {
+			return branches, fmt.Errorf("commitTransaction: refreshing cache for %q: %w", qualified, err)
+		}
 		branches = append(branches, branch)
 	}
 	return branches, nil
@@ -563,14 +564,18 @@ func (state *dbState) updateWorkingRoot(ctx context.Context, branch string, fn f
 		return nil
 	}
 
-	state.workingSets[branch] = newWS
-
 	if skipSync {
-		// j:false: defer the ref flush; deferredFlushLoop drains it.
+		// j:false: defer the ref flush. Cache the new WS in the
+		// singleton entry without touching wsHash so the next
+		// updateBranchWS's optimistic lock still matches disk.
+		state.setBranchWS(branch, newWS)
 		return nil
 	}
 
-	if err := updateWorkingSet(ctx, state.doltDB, newWS, branch); err != nil {
+	// Non-txn, non-skipSync: full update (cache + disk + hash refresh).
+	if err := state.updateBranchWS(ctx, branch, func(_ *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+		return newWS, nil
+	}); err != nil {
 		return fmt.Errorf("updating working set: %w", err)
 	}
 	return nil

--- a/internal/backends/dolt/helpers.go
+++ b/internal/backends/dolt/helpers.go
@@ -394,8 +394,8 @@ func (state *dbState) loadCommittedWS(ctx context.Context, branch string) (*dolt
 	return ws, nil
 }
 
-// GetIfPresent (not Get): background loops (deferredFlushLoop, capped
-// cleanup) run without a ConnInfo and would otherwise panic.
+// GetIfPresent (not Get): background loops (e.g., capped cleanup) run
+// without a ConnInfo and would otherwise panic.
 //
 // In --session-isolation mode every connection is implicitly forked, so
 // the InTransaction check is bypassed.
@@ -564,15 +564,13 @@ func (state *dbState) updateWorkingRoot(ctx context.Context, branch string, fn f
 		return nil
 	}
 
-	if skipSync {
-		// j:false: defer the ref flush. Cache the new WS in the
-		// singleton entry without touching wsHash so the next
-		// updateBranchWS's optimistic lock still matches disk.
-		state.setBranchWS(branch, newWS)
-		return nil
-	}
-
-	// Non-txn, non-skipSync: full update (cache + disk + hash refresh).
+	// Non-txn: full update (cache + disk + hash refresh). skipSync is
+	// ignored: there is no deferred flusher to drain a cache-only write,
+	// so honoring skipSync here would lose data on server restart. The
+	// wire-level writeConcern.j=false is now a no-op for autoCommit /
+	// non-txn writes; session-isolation may grow a commit-time fsync
+	// skip as a future refinement (see docs/design/branch-ws-singletons.md).
+	_ = skipSync
 	if err := state.updateBranchWS(ctx, branch, func(_ *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
 		return newWS, nil
 	}); err != nil {

--- a/internal/backends/dolt/session_writeroutes_test.go
+++ b/internal/backends/dolt/session_writeroutes_test.go
@@ -151,9 +151,9 @@ func TestSession_CrossSessionConcurrentWritesIsolated(t *testing.T) {
 	// Read from the setup session to verify cross-session visibility.
 	state, ok := be.lookupDbStateForDsess(dbName)
 	require.True(t, ok)
-	state.mu.RLock()
-	defer state.mu.RUnlock()
-	rv, err := workingRootViaSession(setupCtx, sessionFromContext(setupCtx), state.workingSets[defaultBranch], dbName, defaultBranch)
+	fallbackWS, err := state.loadBranchWS(setupCtx, defaultBranch)
+	require.NoError(t, err)
+	rv, err := workingRootViaSession(setupCtx, sessionFromContext(setupCtx), fallbackWS, dbName, defaultBranch)
 	require.NoError(t, err)
 	am, err := amFromWorkingRoot(setupCtx, rv, state.ns)
 	require.NoError(t, err)

--- a/internal/sqlctx/session_registry.go
+++ b/internal/sqlctx/session_registry.go
@@ -162,16 +162,3 @@ func (r *SessionRegistry) Len() int {
 	return len(r.sessions)
 }
 
-// ActiveShadows returns a lock-free copy of every active shadow. Used by
-// the deferred flusher to walk sessions outside the registry lock.
-func (r *SessionRegistry) ActiveShadows() []*Shadow {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]*Shadow, 0, len(r.sessions))
-	for _, entry := range r.sessions {
-		if s := entry.shadow.Load(); s != nil && s.Active() {
-			out = append(out, s)
-		}
-	}
-	return out
-}


### PR DESCRIPTION
In prep for GC, remove the hot workingSets map in the global db state object