### PR TITLE
add index specific added/updated/deleted fields in status and diff

### DIFF
--- a/docs/verify/index-branch-isolation.md
+++ b/docs/verify/index-branch-isolation.md
@@ -63,30 +63,35 @@ var am = db.getSiblingDB("idxisovdb@am")
 am.items.createIndex({ name: 1 }, { name: "by_name" })
 
 // dumboStatus reports the working-set delta. The "modified" status
-// with zero doc changes plus the indexesAdded list tells the user
-// what is about to be committed.
+// with zero doc changes plus the addedIndexes list tells the user
+// what is about to be committed. modifiedIndexes / removedIndexes
+// are always present as empty arrays here.
 am.runCommand({ dumboStatus: 1 })
 // Expected: {
 //   branch: "am", dirty: true, readonly: false,
 //   collections: [{
 //     name: "items", status: "modified",
 //     added: 0, modified: 0, deleted: 0,
-//     indexesAdded: [ "by_name" ]
+//     addedIndexes: [ "by_name" ],
+//     modifiedIndexes: [],
+//     removedIndexes: []
 //   }],
 //   ok: 1
 // }
 
 // dumboDiff shows the full definition of the new index so the user
-// can confirm the keys and options before committing.
+// can confirm the keys and options before committing. Each of the
+// six change arrays (3 doc + 3 index) is always present.
 am.runCommand({ dumboDiff: 1 })
 // Expected: {
 //   collections: [{
 //     name: "items", status: "modified",
 //     added: [], removed: [], modified: [],
-//     indexes: [{
-//       name: "by_name", status: "added",
-//       to: { name: "by_name", keys: [{ field: "name", direction: 1 }] }
-//     }]
+//     addedIndexes: [
+//       { name: "by_name", keys: [{ field: "name", direction: 1 }] }
+//     ],
+//     modifiedIndexes: [],
+//     removedIndexes: []
 //   }],
 //   ok: 1
 // }
@@ -108,8 +113,12 @@ db.getSiblingDB("idxisovdb@nz").items.getIndexes().map(i => i.name)
 ```
 
 Key checks:
-- `dumboStatus` shows `indexesAdded: ["by_name"]` on `am` before commit
-- `dumboDiff` shows the full `by_name` definition with status `"added"`
+- `dumboStatus` shows `addedIndexes: ["by_name"]` on `am` before commit;
+  `modifiedIndexes: []` and `removedIndexes: []` are present as empty
+  arrays.
+- `dumboDiff` shows the full `by_name` definition in `addedIndexes[0]`;
+  the other five change arrays (`added`, `removed`, `modified`,
+  `modifiedIndexes`, `removedIndexes`) are present as empty arrays.
 - `am` lists `["_id_", "by_name"]` after commit
 - `main` lists `["_id_"]`
 - `nz` lists `["_id_"]`
@@ -332,25 +341,35 @@ mdb.runCommand({ doltCommit: 1, message: "seed + by_x on age", author: "alice <a
 mdb.items.dropIndex("by_x")
 mdb.items.createIndex({ name: 1 }, { name: "by_x" })
 
-// dumboStatus shows the index as "changed" (same name, different spec).
+// dumboStatus shows the index in modifiedIndexes (not added or removed).
 mdb.runCommand({ dumboStatus: 1 })
-// Expected: collections[0].indexesChanged contains "by_x"
+// Expected: collections[0] = {
+//   ...,
+//   addedIndexes: [],
+//   modifiedIndexes: [ "by_x" ],
+//   removedIndexes: []
+// }
 
-// dumboDiff shows a single "modified" entry with both definitions.
+// dumboDiff shows a single modifiedIndexes entry with both definitions.
 mdb.runCommand({ dumboDiff: 1 })
-// Expected: collections[0].indexes contains one entry:
-//   {
-//     name: "by_x", status: "modified",
-//     from: { name: "by_x", keys: [{ field: "age", direction: 1 }] },
-//     to:   { name: "by_x", keys: [{ field: "name", direction: 1 }] }
-//   }
+// Expected: collections[0] = {
+//   ...,
+//   addedIndexes: [],
+//   modifiedIndexes: [
+//     {
+//       from: { name: "by_x", keys: [{ field: "age",  direction: 1 }] },
+//       to:   { name: "by_x", keys: [{ field: "name", direction: 1 }] }
+//     }
+//   ],
+//   removedIndexes: []
+// }
 ```
 
 Key checks:
-- `dumboStatus` lists `by_x` in `indexesChanged` (not `indexesAdded` or
-  `indexesDeleted`).
-- `dumboDiff` returns one index entry with `status: "modified"` and both
-  `from` (old keys) and `to` (new keys) populated.
+- `dumboStatus` lists `by_x` in `modifiedIndexes` (not `addedIndexes` or
+  `removedIndexes`).
+- `dumboDiff` returns one `modifiedIndexes` entry with both `from` (old
+  keys) and `to` (new keys) populated.
 
 ---
 

--- a/docs/verify/log.md
+++ b/docs/verify/log.md
@@ -565,35 +565,45 @@ idb.runCommand({ doltCommit: 1, message: "seed", author: "alice <alice@acme.com>
 idb.items.createIndex({ age: 1 }, { name: "by_age" })
 idb.runCommand({ doltCommit: 1, message: "add by_age", author: "alice <alice@acme.com>" })
 
-// stat shows indexesAdded on the head commit.
+// stat shows addedIndexes on the head commit. modifiedIndexes and
+// removedIndexes are always present as empty arrays.
 idb.runCommand({ doltLog: 1, limit: 1, stat: true })
 // Expected: commits[0].stat[0] = {
 //   name: "items", status: "modified",
 //   added: 0, modified: 0, deleted: 0,
-//   indexesAdded: [ "by_age" ]
+//   addedIndexes: [ "by_age" ],
+//   modifiedIndexes: [],
+//   removedIndexes: []
 // }
 
-// patch shows the full index definition.
+// patch shows the full index definition in addedIndexes. All other
+// change arrays (added/removed/modified docs, modifiedIndexes,
+// removedIndexes) are present as empty arrays.
 idb.runCommand({ doltLog: 1, limit: 1, patch: true })
-// Expected: commits[0].diff[0].indexes = [{
-//   name: "by_age", status: "added",
-//   to: { name: "by_age", keys: [{ field: "age", direction: 1 }] }
-// }]
+// Expected: commits[0].diff[0] = {
+//   ...,
+//   addedIndexes: [
+//     { name: "by_age", keys: [{ field: "age", direction: 1 }] }
+//   ],
+//   modifiedIndexes: [],
+//   removedIndexes: []
+// }
 ```
 
 Key checks:
-- `stat[0].indexesAdded` contains `"by_age"` even though `added/modified/
-  deleted` are all `0`.
-- `diff[0].indexes` is present with one entry: status `"added"`, no
-  `from`, `to` carries the full IndexInfo (name, keys with direction).
+- `stat[0].addedIndexes` contains `"by_age"` even though `added/modified/
+  deleted` are all `0`. `modifiedIndexes` and `removedIndexes` are
+  present as empty arrays.
+- `diff[0].addedIndexes` has one entry: full IndexInfo (name, keys with
+  direction). `modifiedIndexes` and `removedIndexes` are present as
+  empty arrays.
 - The commit is NOT silently dropped from `diff`; before this fix, an
   index-only commit would not appear in patch output because the
   document-level diff was empty.
 
 For the drop+recreate-with-different-spec case, `stat` lists the name in
-`indexesChanged` and `patch` shows a single `indexes[]` entry with
-status `"modified"` carrying both `from` and `to` (see
-`index-branch-isolation.md` Scenario 8).
+`modifiedIndexes` and `patch` shows a single `modifiedIndexes` entry
+with both `from` and `to` (see `index-branch-isolation.md` Scenario 8).
 
 ---
 

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -2302,9 +2302,9 @@ func (b *Backend) DumboDBLog(ctx context.Context, params *backends.LogParams) (*
 				}
 
 				// Index lifecycle is content-addressed; the same helper that
-				// powers DumboDBStatus / DumboDBDiff reduces the two DTBLs to
-				// per-index added/deleted/modified.
-				idxDiffs, idxErr := computeIndexDiffs(ctx, db, aHash, bHash)
+				// powers DumboDBStatus / DumboDBDiff reduces the two DTBLs
+				// to per-kind added/modified/removed lists.
+				idxAdded, idxModified, idxRemoved, idxErr := computeIndexChanges(ctx, db, aHash, bHash)
 				if idxErr != nil {
 					return nil, fmt.Errorf("DumboDBLog: index diffs for %q in commit %q: %w", name, ci.Hash.String(), idxErr)
 				}
@@ -2313,21 +2313,16 @@ func (b *Backend) DumboDBLog(ctx context.Context, params *backends.LogParams) (*
 					aMap, _ := collectionMapFromAM(ctx, db, parentAM, name)
 					bMap, _ := collectionMapFromAM(ctx, db, commitAM, name)
 					added, modified, deleted, _ := countCollectionMapDiffs(ctx, aMap, bMap)
-					ts := backends.TableStatus{
-						Name: name, Status: status,
-						Added: added, Modified: modified, Deleted: deleted,
-					}
-					for _, d := range idxDiffs {
-						switch d.Status {
-						case "added":
-							ts.IndexesAdded = append(ts.IndexesAdded, d.Name)
-						case "deleted":
-							ts.IndexesDeleted = append(ts.IndexesDeleted, d.Name)
-						case "modified":
-							ts.IndexesChanged = append(ts.IndexesChanged, d.Name)
-						}
-					}
-					info.Stat = append(info.Stat, ts)
+					info.Stat = append(info.Stat, backends.TableStatus{
+						Name:            name,
+						Status:          status,
+						Added:           added,
+						Modified:        modified,
+						Deleted:         deleted,
+						AddedIndexes:    indexNamesOf(idxAdded),
+						ModifiedIndexes: indexChangeNamesOf(idxModified),
+						RemovedIndexes:  indexNamesOf(idxRemoved),
+					})
 				}
 
 				if params.Patch {
@@ -2337,11 +2332,17 @@ func (b *Backend) DumboDBLog(ctx context.Context, params *backends.LogParams) (*
 					// Include the collection's diff entry if any document
 					// OR any index changed. An index-only commit was
 					// silently dropped before this check.
-					if len(addedDocs) > 0 || len(removedDocs) > 0 || len(modifiedDocs) > 0 || len(idxDiffs) > 0 {
+					if len(addedDocs) > 0 || len(removedDocs) > 0 || len(modifiedDocs) > 0 ||
+						len(idxAdded) > 0 || len(idxModified) > 0 || len(idxRemoved) > 0 {
 						info.Diff = append(info.Diff, backends.CollectionDiff{
-							Name: name, Status: status,
-							Added: addedDocs, Removed: removedDocs, Modified: modifiedDocs,
-							Indexes: idxDiffs,
+							Name:            name,
+							Status:          status,
+							Added:           addedDocs,
+							Removed:         removedDocs,
+							Modified:        modifiedDocs,
+							AddedIndexes:    idxAdded,
+							ModifiedIndexes: idxModified,
+							RemovedIndexes:  idxRemoved,
 						})
 					}
 				}
@@ -2434,27 +2435,20 @@ func (b *Backend) DumboDBStatus(ctx context.Context, params *backends.Versioning
 			return nil, fmt.Errorf("DumboDBStatus: counting diffs for %q.%q: %w", params.DBName, name, countErr)
 		}
 
-		idxDiffs, idxErr := computeIndexDiffs(ctx, state, headHash, workingHash)
+		idxAdded, idxModified, idxRemoved, idxErr := computeIndexChanges(ctx, state, headHash, workingHash)
 		if idxErr != nil {
 			return nil, fmt.Errorf("DumboDBStatus: computing index diffs for %q.%q: %w", params.DBName, name, idxErr)
 		}
 
 		ts := backends.TableStatus{
-			Name:     name,
-			Status:   status,
-			Added:    addedCount,
-			Modified: modifiedCount,
-			Deleted:  deletedCount,
-		}
-		for _, d := range idxDiffs {
-			switch d.Status {
-			case "added":
-				ts.IndexesAdded = append(ts.IndexesAdded, d.Name)
-			case "deleted":
-				ts.IndexesDeleted = append(ts.IndexesDeleted, d.Name)
-			case "modified":
-				ts.IndexesChanged = append(ts.IndexesChanged, d.Name)
-			}
+			Name:            name,
+			Status:          status,
+			Added:           addedCount,
+			Modified:        modifiedCount,
+			Deleted:         deletedCount,
+			AddedIndexes:    indexNamesOf(idxAdded),
+			ModifiedIndexes: indexChangeNamesOf(idxModified),
+			RemovedIndexes:  indexNamesOf(idxRemoved),
 		}
 		tables = append(tables, ts)
 	}
@@ -2709,7 +2703,7 @@ func (b *Backend) DumboDBDiff(ctx context.Context, params *backends.DiffParams) 
 			return nil, fmt.Errorf("DumboDBDiff: diffing collection %q in db %q: %w", name, params.DBName, diffErr)
 		}
 
-		idxDiffs, idxErr := computeIndexDiffs(ctx, state, aHash, bHash)
+		idxAdded, idxModified, idxRemoved, idxErr := computeIndexChanges(ctx, state, aHash, bHash)
 		if idxErr != nil {
 			return nil, fmt.Errorf("DumboDBDiff: index diffs for %q in db %q: %w", name, params.DBName, idxErr)
 		}
@@ -2718,17 +2712,20 @@ func (b *Backend) DumboDBDiff(ctx context.Context, params *backends.DiffParams) 
 		// index-level changes is no diff at all. "added" and "deleted"
 		// collections always surface, even when empty, so the caller can
 		// see the lifecycle event.
-		if status == "modified" && len(added) == 0 && len(removed) == 0 && len(modified) == 0 && len(idxDiffs) == 0 {
+		if status == "modified" && len(added) == 0 && len(removed) == 0 && len(modified) == 0 &&
+			len(idxAdded) == 0 && len(idxModified) == 0 && len(idxRemoved) == 0 {
 			continue
 		}
 
 		diffs = append(diffs, backends.CollectionDiff{
-			Name:     name,
-			Status:   status,
-			Added:    added,
-			Removed:  removed,
-			Modified: modified,
-			Indexes:  idxDiffs,
+			Name:            name,
+			Status:          status,
+			Added:           added,
+			Removed:         removed,
+			Modified:        modified,
+			AddedIndexes:    idxAdded,
+			ModifiedIndexes: idxModified,
+			RemovedIndexes:  idxRemoved,
 		})
 	}
 

--- a/internal/backends/dolt/index_diff_test.go
+++ b/internal/backends/dolt/index_diff_test.go
@@ -49,11 +49,11 @@ func TestStatus_IndexAddedSurfaces(t *testing.T) {
 	if got.Status != "modified" || got.Added != 0 || got.Modified != 0 || got.Deleted != 0 {
 		t.Errorf("expected modified with zero doc changes, got %+v", got)
 	}
-	if !reflect.DeepEqual(got.IndexesAdded, []string{"by_age"}) {
-		t.Errorf("IndexesAdded = %v, want [by_age]", got.IndexesAdded)
+	if !reflect.DeepEqual(got.AddedIndexes, []string{"by_age"}) {
+		t.Errorf("AddedIndexes = %v, want [by_age]", got.AddedIndexes)
 	}
-	if len(got.IndexesChanged) != 0 || len(got.IndexesDeleted) != 0 {
-		t.Errorf("expected no changed/deleted indexes, got changed=%v deleted=%v", got.IndexesChanged, got.IndexesDeleted)
+	if len(got.ModifiedIndexes) != 0 || len(got.RemovedIndexes) != 0 {
+		t.Errorf("expected no modified/removed indexes, got modified=%v removed=%v", got.ModifiedIndexes, got.RemovedIndexes)
 	}
 }
 
@@ -81,8 +81,8 @@ func TestStatus_IndexDeletedSurfaces(t *testing.T) {
 		t.Fatalf("expected one modified collection, got %d", len(res.Tables))
 	}
 	got := res.Tables[0]
-	if !reflect.DeepEqual(got.IndexesDeleted, []string{"by_age"}) {
-		t.Errorf("IndexesDeleted = %v, want [by_age]", got.IndexesDeleted)
+	if !reflect.DeepEqual(got.RemovedIndexes, []string{"by_age"}) {
+		t.Errorf("RemovedIndexes = %v, want [by_age]", got.RemovedIndexes)
 	}
 }
 
@@ -112,11 +112,11 @@ func TestStatus_IndexChangedSurfaces(t *testing.T) {
 		t.Fatalf("expected one modified collection, got %d", len(res.Tables))
 	}
 	got := res.Tables[0]
-	if !reflect.DeepEqual(got.IndexesChanged, []string{"by_x"}) {
-		t.Errorf("IndexesChanged = %v, want [by_x]", got.IndexesChanged)
+	if !reflect.DeepEqual(got.ModifiedIndexes, []string{"by_x"}) {
+		t.Errorf("ModifiedIndexes = %v, want [by_x]", got.ModifiedIndexes)
 	}
-	if len(got.IndexesAdded) != 0 || len(got.IndexesDeleted) != 0 {
-		t.Errorf("expected only IndexesChanged; got added=%v deleted=%v", got.IndexesAdded, got.IndexesDeleted)
+	if len(got.AddedIndexes) != 0 || len(got.RemovedIndexes) != 0 {
+		t.Errorf("expected only ModifiedIndexes; got added=%v removed=%v", got.AddedIndexes, got.RemovedIndexes)
 	}
 }
 
@@ -144,27 +144,21 @@ func TestDiff_IndexAddedSurfaces(t *testing.T) {
 	if got.Name != "items" || got.Status != "modified" {
 		t.Errorf("collection = %+v, want name=items status=modified", got)
 	}
-	if len(got.Indexes) != 1 {
-		t.Fatalf("expected one index diff, got %d", len(got.Indexes))
+	if len(got.AddedIndexes) != 1 {
+		t.Fatalf("expected one added index, got %d", len(got.AddedIndexes))
 	}
-	idx := got.Indexes[0]
-	if idx.Name != "by_age" || idx.Status != "added" {
-		t.Errorf("idx diff = %+v, want name=by_age status=added", idx)
+	if len(got.ModifiedIndexes) != 0 || len(got.RemovedIndexes) != 0 {
+		t.Errorf("expected only AddedIndexes; got modified=%v removed=%v", got.ModifiedIndexes, got.RemovedIndexes)
 	}
-	if idx.From != nil {
-		t.Errorf("expected From=nil for added, got %+v", idx.From)
-	}
-	if idx.To == nil {
-		t.Fatalf("expected To populated for added")
-	}
-	if idx.To.Name != "by_age" || len(idx.To.Key) != 1 || idx.To.Key[0].Field != "age" {
-		t.Errorf("idx.To = %+v, want by_age on field age", idx.To)
+	idx := got.AddedIndexes[0]
+	if idx.Name != "by_age" || len(idx.Key) != 1 || idx.Key[0].Field != "age" {
+		t.Errorf("added index = %+v, want by_age on field age", idx)
 	}
 }
 
 // TestDiff_IndexChangedShowsBothDefinitions: a same-name drop+recreate
-// with a different spec must surface as a "modified" IndexDiff carrying
-// both From (old spec) and To (new spec).
+// with a different spec must surface as a ModifiedIndexes entry
+// carrying both From (old spec) and To (new spec).
 func TestDiff_IndexChangedShowsBothDefinitions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -184,21 +178,25 @@ func TestDiff_IndexChangedShowsBothDefinitions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DumboDBDiff: %v", err)
 	}
-	if len(res.Collections) != 1 || len(res.Collections[0].Indexes) != 1 {
-		t.Fatalf("expected one collection with one index diff, got %+v", res.Collections)
+	if len(res.Collections) != 1 {
+		t.Fatalf("expected one collection in diff, got %d", len(res.Collections))
 	}
-	idx := res.Collections[0].Indexes[0]
-	if idx.Status != "modified" {
-		t.Errorf("idx.Status = %q, want modified", idx.Status)
+	got := res.Collections[0]
+	if len(got.AddedIndexes) != 0 || len(got.RemovedIndexes) != 0 {
+		t.Errorf("expected only ModifiedIndexes; got added=%v removed=%v", got.AddedIndexes, got.RemovedIndexes)
 	}
-	if idx.From == nil || idx.To == nil {
-		t.Fatalf("modified diff must include both From and To")
+	if len(got.ModifiedIndexes) != 1 {
+		t.Fatalf("expected one modified index, got %d", len(got.ModifiedIndexes))
 	}
-	if len(idx.From.Key) != 1 || idx.From.Key[0].Field != "age" {
-		t.Errorf("From key = %+v, want field=age", idx.From.Key)
+	ch := got.ModifiedIndexes[0]
+	if ch.From.Name != "by_x" || ch.To.Name != "by_x" {
+		t.Errorf("change names = (%q, %q), want both by_x", ch.From.Name, ch.To.Name)
 	}
-	if len(idx.To.Key) != 1 || idx.To.Key[0].Field != "name" {
-		t.Errorf("To key = %+v, want field=name", idx.To.Key)
+	if len(ch.From.Key) != 1 || ch.From.Key[0].Field != "age" {
+		t.Errorf("From key = %+v, want field=age", ch.From.Key)
+	}
+	if len(ch.To.Key) != 1 || ch.To.Key[0].Field != "name" {
+		t.Errorf("To key = %+v, want field=name", ch.To.Key)
 	}
 }
 
@@ -244,30 +242,31 @@ func TestLog_StatAndPatch_IncludeIndexChanges(t *testing.T) {
 	if len(c3.Stat) != 1 {
 		t.Fatalf("c3 stat: expected one collection, got %d", len(c3.Stat))
 	}
-	if !reflect.DeepEqual(c3.Stat[0].IndexesChanged, []string{"by_age"}) {
-		t.Errorf("c3 stat IndexesChanged = %v, want [by_age]", c3.Stat[0].IndexesChanged)
+	if !reflect.DeepEqual(c3.Stat[0].ModifiedIndexes, []string{"by_age"}) {
+		t.Errorf("c3 stat ModifiedIndexes = %v, want [by_age]", c3.Stat[0].ModifiedIndexes)
 	}
-	if len(c3.Diff) != 1 || len(c3.Diff[0].Indexes) != 1 {
-		t.Fatalf("c3 diff: expected one collection with one index diff, got %+v", c3.Diff)
+	if len(c3.Diff) != 1 || len(c3.Diff[0].ModifiedIndexes) != 1 {
+		t.Fatalf("c3 diff: expected one collection with one modified index, got %+v", c3.Diff)
 	}
-	if c3.Diff[0].Indexes[0].Status != "modified" || c3.Diff[0].Indexes[0].From == nil || c3.Diff[0].Indexes[0].To == nil {
-		t.Errorf("c3 modified index diff malformed: %+v", c3.Diff[0].Indexes[0])
+	ch := c3.Diff[0].ModifiedIndexes[0]
+	if ch.From.Name != "by_age" || ch.To.Name != "by_age" {
+		t.Errorf("c3 modified change names = (%q, %q), want both by_age", ch.From.Name, ch.To.Name)
 	}
 
 	// c2: added by_age. This is the bug fix case -- previously the patch
 	// filter dropped it because addedDocs/removedDocs/modifiedDocs were
 	// all empty.
-	if len(c2.Stat) != 1 || !reflect.DeepEqual(c2.Stat[0].IndexesAdded, []string{"by_age"}) {
-		t.Errorf("c2 stat = %+v, want IndexesAdded=[by_age]", c2.Stat)
+	if len(c2.Stat) != 1 || !reflect.DeepEqual(c2.Stat[0].AddedIndexes, []string{"by_age"}) {
+		t.Errorf("c2 stat = %+v, want AddedIndexes=[by_age]", c2.Stat)
 	}
 	if len(c2.Diff) != 1 {
 		t.Fatalf("c2 diff: expected one collection in patch (was dropped before the fix), got %d", len(c2.Diff))
 	}
-	if len(c2.Diff[0].Indexes) != 1 || c2.Diff[0].Indexes[0].Status != "added" {
-		t.Errorf("c2 diff Indexes = %+v, want one entry with status=added", c2.Diff[0].Indexes)
+	if len(c2.Diff[0].AddedIndexes) != 1 {
+		t.Fatalf("c2 diff AddedIndexes = %+v, want one entry", c2.Diff[0].AddedIndexes)
 	}
-	if c2.Diff[0].Indexes[0].To == nil || c2.Diff[0].Indexes[0].To.Name != "by_age" {
-		t.Errorf("c2 diff added entry missing To: %+v", c2.Diff[0].Indexes[0])
+	if c2.Diff[0].AddedIndexes[0].Name != "by_age" {
+		t.Errorf("c2 added entry name = %q, want by_age", c2.Diff[0].AddedIndexes[0].Name)
 	}
 }
 
@@ -299,22 +298,48 @@ func TestDiff_MultipleIndexChanges(t *testing.T) {
 	if len(res.Collections) != 1 {
 		t.Fatalf("expected one collection in diff, got %d", len(res.Collections))
 	}
-	indexes := res.Collections[0].Indexes
-	names := make([]string, len(indexes))
-	statuses := make([]string, len(indexes))
-	for i, idx := range indexes {
-		names[i] = idx.Name
-		statuses[i] = idx.Status
+	got := res.Collections[0]
+
+	// Each list is itself sorted by name. AddedIndexes carries
+	// "by_name", RemovedIndexes carries "by_age", ModifiedIndexes
+	// carries "by_swap".
+	addedNames := indexInfoNames(got.AddedIndexes)
+	removedNames := indexInfoNames(got.RemovedIndexes)
+	modifiedNames := indexChangeNames(got.ModifiedIndexes)
+	if !sort.StringsAreSorted(addedNames) {
+		t.Errorf("added not sorted: %v", addedNames)
 	}
-	if !sort.StringsAreSorted(names) {
-		t.Errorf("index diffs not sorted by name: %v", names)
+	if !sort.StringsAreSorted(removedNames) {
+		t.Errorf("removed not sorted: %v", removedNames)
 	}
-	wantNames := []string{"by_age", "by_name", "by_swap"}
-	wantStatus := []string{"deleted", "added", "modified"}
-	if !reflect.DeepEqual(names, wantNames) {
-		t.Errorf("names = %v, want %v", names, wantNames)
+	if !sort.StringsAreSorted(modifiedNames) {
+		t.Errorf("modified not sorted: %v", modifiedNames)
 	}
-	if !reflect.DeepEqual(statuses, wantStatus) {
-		t.Errorf("statuses = %v, want %v", statuses, wantStatus)
+	if !reflect.DeepEqual(addedNames, []string{"by_name"}) {
+		t.Errorf("added = %v, want [by_name]", addedNames)
 	}
+	if !reflect.DeepEqual(removedNames, []string{"by_age"}) {
+		t.Errorf("removed = %v, want [by_age]", removedNames)
+	}
+	if !reflect.DeepEqual(modifiedNames, []string{"by_swap"}) {
+		t.Errorf("modified = %v, want [by_swap]", modifiedNames)
+	}
+}
+
+// indexInfoNames extracts names from a []IndexInfo for test assertions.
+func indexInfoNames(infos []backends.IndexInfo) []string {
+	out := make([]string, len(infos))
+	for i, info := range infos {
+		out[i] = info.Name
+	}
+	return out
+}
+
+// indexChangeNames extracts From.Name from each IndexChange.
+func indexChangeNames(changes []backends.IndexChange) []string {
+	out := make([]string, len(changes))
+	for i, c := range changes {
+		out[i] = c.From.Name
+	}
+	return out
 }

--- a/internal/backends/dolt/index_resolve.go
+++ b/internal/backends/dolt/index_resolve.go
@@ -337,42 +337,45 @@ func buildIndexAM(ctx context.Context, state *dbState, infos []backends.IndexInf
 	return newAM, nil
 }
 
-// computeIndexDiffs compares the secondary-index AMs of two DTBL hashes
-// and returns the per-index lifecycle changes. An index is:
-//   - "added"   when only the b side has it,
-//   - "deleted" when only the a side has it,
-//   - "modified" when both sides carry the same name but different
-//                IndexEntry chunk hashes (drop+recreate with a different
-//                spec).
+// computeIndexChanges compares the secondary-index AMs of two DTBL
+// hashes and returns the per-kind index lifecycle: added, modified, and
+// removed. An index is:
+//   - added    when only the b side has it,
+//   - removed  when only the a side has it,
+//   - modified when both sides carry the same name but different
+//              IndexEntry chunk hashes (drop+recreate with a different
+//              spec).
 //
 // Either hash may be the zero hash (collection absent on that side); in
-// that case the index list for that side is empty.
+// that case the corresponding side's index list is empty.
 //
-// Results are sorted by index name. The IndexInfo pointers in From/To
-// are decoded via resolveIndexEntry (memoized).
-func computeIndexDiffs(ctx context.Context, state *dbState, aDTBL, bDTBL hash.Hash) ([]backends.IndexDiff, error) {
+// All three returned slices are sorted by index name. The IndexInfo
+// values are decoded via resolveIndexEntry (memoized). Each IndexChange
+// in modified carries both the pre-state (From) and post-state (To)
+// definitions; the index name is From.Name == To.Name.
+func computeIndexChanges(ctx context.Context, state *dbState, aDTBL, bDTBL hash.Hash) (added []backends.IndexInfo, modified []backends.IndexChange, removed []backends.IndexInfo, err error) {
 	aAM, err := indexAMForDTBL(ctx, state.cs, state.ns, aDTBL)
 	if err != nil {
-		return nil, fmt.Errorf("computeIndexDiffs: a side: %w", err)
+		return nil, nil, nil, fmt.Errorf("computeIndexChanges: a side: %w", err)
 	}
 	bAM, err := indexAMForDTBL(ctx, state.cs, state.ns, bDTBL)
 	if err != nil {
-		return nil, fmt.Errorf("computeIndexDiffs: b side: %w", err)
+		return nil, nil, nil, fmt.Errorf("computeIndexChanges: b side: %w", err)
 	}
 
 	aEntries := make(map[string]hash.Hash)
-	if err := aAM.IterAll(ctx, func(name string, h hash.Hash) error {
+	if err = aAM.IterAll(ctx, func(name string, h hash.Hash) error {
 		aEntries[name] = h
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("computeIndexDiffs: walking a side: %w", err)
+		return nil, nil, nil, fmt.Errorf("computeIndexChanges: walking a side: %w", err)
 	}
 	bEntries := make(map[string]hash.Hash)
-	if err := bAM.IterAll(ctx, func(name string, h hash.Hash) error {
+	if err = bAM.IterAll(ctx, func(name string, h hash.Hash) error {
 		bEntries[name] = h
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("computeIndexDiffs: walking b side: %w", err)
+		return nil, nil, nil, fmt.Errorf("computeIndexChanges: walking b side: %w", err)
 	}
 
 	allNames := make(map[string]struct{}, len(aEntries)+len(bEntries))
@@ -388,40 +391,63 @@ func computeIndexDiffs(ctx context.Context, state *dbState, aDTBL, bDTBL hash.Ha
 	}
 	sort.Strings(sorted)
 
-	var out []backends.IndexDiff
 	for _, name := range sorted {
 		aH, inA := aEntries[name]
 		bH, inB := bEntries[name]
 		switch {
 		case !inA && inB:
-			info, err := resolveIndexEntry(ctx, state.ns, bH)
-			if err != nil {
-				return nil, fmt.Errorf("computeIndexDiffs: resolving b entry for %q: %w", name, err)
+			info, rerr := resolveIndexEntry(ctx, state.ns, bH)
+			if rerr != nil {
+				return nil, nil, nil, fmt.Errorf("computeIndexChanges: resolving b entry for %q: %w", name, rerr)
 			}
-			toCopy := info.info
-			out = append(out, backends.IndexDiff{Name: name, Status: "added", To: &toCopy})
+			added = append(added, info.info)
 		case inA && !inB:
-			info, err := resolveIndexEntry(ctx, state.ns, aH)
-			if err != nil {
-				return nil, fmt.Errorf("computeIndexDiffs: resolving a entry for %q: %w", name, err)
+			info, rerr := resolveIndexEntry(ctx, state.ns, aH)
+			if rerr != nil {
+				return nil, nil, nil, fmt.Errorf("computeIndexChanges: resolving a entry for %q: %w", name, rerr)
 			}
-			fromCopy := info.info
-			out = append(out, backends.IndexDiff{Name: name, Status: "deleted", From: &fromCopy})
+			removed = append(removed, info.info)
 		case aH != bH:
-			aInfo, err := resolveIndexEntry(ctx, state.ns, aH)
-			if err != nil {
-				return nil, fmt.Errorf("computeIndexDiffs: resolving a entry for %q: %w", name, err)
+			aInfo, rerr := resolveIndexEntry(ctx, state.ns, aH)
+			if rerr != nil {
+				return nil, nil, nil, fmt.Errorf("computeIndexChanges: resolving a entry for %q: %w", name, rerr)
 			}
-			bInfo, err := resolveIndexEntry(ctx, state.ns, bH)
-			if err != nil {
-				return nil, fmt.Errorf("computeIndexDiffs: resolving b entry for %q: %w", name, err)
+			bInfo, rerr := resolveIndexEntry(ctx, state.ns, bH)
+			if rerr != nil {
+				return nil, nil, nil, fmt.Errorf("computeIndexChanges: resolving b entry for %q: %w", name, rerr)
 			}
-			fromCopy := aInfo.info
-			toCopy := bInfo.info
-			out = append(out, backends.IndexDiff{Name: name, Status: "modified", From: &fromCopy, To: &toCopy})
+			modified = append(modified, backends.IndexChange{From: aInfo.info, To: bInfo.info})
 		}
 	}
-	return out, nil
+	return added, modified, removed, nil
+}
+
+// indexNamesOf extracts the Name field from each IndexInfo, in input
+// order. Returns a nil slice for nil input so callers passing a status
+// row through json.Marshal-style code can rely on "always emit []"
+// downstream by len-checking, not nil-checking.
+func indexNamesOf(infos []backends.IndexInfo) []string {
+	if len(infos) == 0 {
+		return nil
+	}
+	out := make([]string, len(infos))
+	for i, info := range infos {
+		out[i] = info.Name
+	}
+	return out
+}
+
+// indexChangeNamesOf extracts the index name from each IndexChange.
+// From.Name == To.Name by construction (same-name drop+recreate).
+func indexChangeNamesOf(changes []backends.IndexChange) []string {
+	if len(changes) == 0 {
+		return nil
+	}
+	out := make([]string, len(changes))
+	for i, c := range changes {
+		out[i] = c.From.Name
+	}
+	return out
 }
 
 // openIndexMap returns a prolly.Map handle for the secondary-index data

--- a/internal/backends/versioning.go
+++ b/internal/backends/versioning.go
@@ -219,12 +219,16 @@ type TableStatus struct {
 	Deleted  int
 
 	// Index lifecycle, name-only for the brief view. An index appears in
-	// IndexesChanged when the same name is present on both sides with
+	// ModifiedIndexes when the same name is present on both sides with
 	// different definitions -- i.e. drop+recreate within the uncommitted
 	// working set. Full per-index detail surfaces through DumboDBDiff.
-	IndexesAdded   []string
-	IndexesChanged []string
-	IndexesDeleted []string
+	//
+	// Callers must always emit all three on the wire as empty arrays
+	// when there are no changes of that kind, so consumers do not have
+	// to branch on field presence.
+	AddedIndexes    []string
+	ModifiedIndexes []string
+	RemovedIndexes  []string
 }
 
 type VersioningStatusResult struct {
@@ -267,25 +271,29 @@ type ModifiedDoc struct {
 	Diff []FieldDiff
 }
 
-// IndexDiff represents the change to a single secondary index between two
-// states. Indexes are content-addressed by their full definition, so a
-// "modified" entry means the same name exists on both sides with a
-// different spec -- the index was dropped and recreated.
-type IndexDiff struct {
-	Name   string
-	Status string     // "added", "deleted", or "modified"
-	From   *IndexInfo // pre-state definition; nil when Status == "added"
-	To     *IndexInfo // post-state definition; nil when Status == "deleted"
+// IndexChange represents a secondary index that has the same name on
+// both sides with a different definition. From and To both carry the
+// full IndexInfo. The Name field is implicit (From.Name == To.Name).
+type IndexChange struct {
+	From IndexInfo
+	To   IndexInfo
 }
 
 // CollectionDiff represents the changes to a single collection.
+//
+// The three index slices are symmetric with the three document slices:
+// each lists entries of one kind, with full detail per entry. Callers
+// must always emit all six on the wire as empty arrays when empty, so
+// consumers do not have to branch on field presence.
 type CollectionDiff struct {
-	Name     string
-	Status   string            // "added" (only in b), "deleted" (only in a), or "modified" (in both with doc or index changes)
-	Added    []*types.Document // full documents added in "b"
-	Removed  []*types.Document // full documents removed from "a"
-	Modified []ModifiedDoc     // documents changed between "a" and "b"
-	Indexes  []IndexDiff       // secondary-index lifecycle between "a" and "b"
+	Name            string
+	Status          string            // "added" (only in b), "deleted" (only in a), or "modified" (in both with doc or index changes)
+	Added           []*types.Document // full documents added in "b"
+	Removed         []*types.Document // full documents removed from "a"
+	Modified        []ModifiedDoc     // documents changed between "a" and "b"
+	AddedIndexes    []IndexInfo       // full definitions of indexes added in "b"
+	ModifiedIndexes []IndexChange     // pre/post definitions for indexes whose spec changed
+	RemovedIndexes  []IndexInfo       // full definitions of indexes removed from "a"
 }
 
 // DiffResult represents the result of VersioningBackend.DumboDBDiff method.

--- a/internal/handler/msg_dumbodb_versioning.go
+++ b/internal/handler/msg_dumbodb_versioning.go
@@ -111,45 +111,32 @@ func (h *Handler) MsgDumboDBDiff(connCtx context.Context, msg *wire.OpMsg) (*wir
 }
 
 // tableStatusToDoc renders a backends.TableStatus as a wire document.
-// Shared by MsgDumboDBStatus and the Stat block of MsgDumboDBLog so
-// the two surfaces stay consistent (notably for the index-lifecycle
-// fields).
+// Shared by MsgDumboDBStatus and the Stat block of MsgDumboDBLog. The
+// three index name lists are ALWAYS emitted, as empty arrays when
+// nothing of that kind changed, so consumers do not have to branch on
+// field presence.
 func tableStatusToDoc(t backends.TableStatus) *types.Document {
-	pairs := []any{
+	return must.NotFail(types.NewDocument(
 		"name", t.Name,
 		"status", t.Status,
 		"added", int32(t.Added),
 		"modified", int32(t.Modified),
 		"deleted", int32(t.Deleted),
-	}
-	if len(t.IndexesAdded) > 0 {
-		arr := types.MakeArray(len(t.IndexesAdded))
-		for _, n := range t.IndexesAdded {
-			arr.Append(n)
-		}
-		pairs = append(pairs, "indexesAdded", arr)
-	}
-	if len(t.IndexesChanged) > 0 {
-		arr := types.MakeArray(len(t.IndexesChanged))
-		for _, n := range t.IndexesChanged {
-			arr.Append(n)
-		}
-		pairs = append(pairs, "indexesChanged", arr)
-	}
-	if len(t.IndexesDeleted) > 0 {
-		arr := types.MakeArray(len(t.IndexesDeleted))
-		for _, n := range t.IndexesDeleted {
-			arr.Append(n)
-		}
-		pairs = append(pairs, "indexesDeleted", arr)
-	}
-	return must.NotFail(types.NewDocument(pairs...))
+		"addedIndexes", stringArray(t.AddedIndexes),
+		"modifiedIndexes", stringArray(t.ModifiedIndexes),
+		"removedIndexes", stringArray(t.RemovedIndexes),
+	))
 }
 
 // collectionDiffToDoc renders a backends.CollectionDiff as a wire
 // document. Shared by MsgDumboDBDiff and the Patch block of
-// MsgDumboDBLog. The added/removed/modified arrays may be empty (for an
-// index-only diff); the indexes array is populated when present.
+// MsgDumboDBLog. All six change arrays (added/removed/modified for
+// docs and addedIndexes/modifiedIndexes/removedIndexes for indexes)
+// are always emitted, empty when there's no change of that kind.
+//
+// addedIndexes and removedIndexes carry full IndexInfo entries.
+// modifiedIndexes carries {from, to} pairs with the full IndexInfo on
+// each side.
 func collectionDiffToDoc(cd backends.CollectionDiff) *types.Document {
 	added := types.MakeArray(len(cd.Added))
 	for _, doc := range cd.Added {
@@ -177,31 +164,47 @@ func collectionDiffToDoc(cd backends.CollectionDiff) *types.Document {
 			"diff", diffArray,
 		)))
 	}
-	pairs := []any{
+
+	addedIdx := types.MakeArray(len(cd.AddedIndexes))
+	for _, info := range cd.AddedIndexes {
+		i := info
+		addedIdx.Append(indexInfoToDoc(&i))
+	}
+	removedIdx := types.MakeArray(len(cd.RemovedIndexes))
+	for _, info := range cd.RemovedIndexes {
+		i := info
+		removedIdx.Append(indexInfoToDoc(&i))
+	}
+	modifiedIdx := types.MakeArray(len(cd.ModifiedIndexes))
+	for _, ch := range cd.ModifiedIndexes {
+		from := ch.From
+		to := ch.To
+		modifiedIdx.Append(must.NotFail(types.NewDocument(
+			"from", indexInfoToDoc(&from),
+			"to", indexInfoToDoc(&to),
+		)))
+	}
+
+	return must.NotFail(types.NewDocument(
 		"name", cd.Name,
 		"status", cd.Status,
 		"added", added,
 		"removed", removed,
 		"modified", modified,
+		"addedIndexes", addedIdx,
+		"modifiedIndexes", modifiedIdx,
+		"removedIndexes", removedIdx,
+	))
+}
+
+// stringArray renders a []string as a wire-array, returning an empty
+// array (not nil) for nil/empty input.
+func stringArray(s []string) *types.Array {
+	arr := types.MakeArray(len(s))
+	for _, v := range s {
+		arr.Append(v)
 	}
-	if len(cd.Indexes) > 0 {
-		indexes := types.MakeArray(len(cd.Indexes))
-		for _, idx := range cd.Indexes {
-			idxPairs := []any{
-				"name", idx.Name,
-				"status", idx.Status,
-			}
-			if idx.From != nil {
-				idxPairs = append(idxPairs, "from", indexInfoToDoc(idx.From))
-			}
-			if idx.To != nil {
-				idxPairs = append(idxPairs, "to", indexInfoToDoc(idx.To))
-			}
-			indexes.Append(must.NotFail(types.NewDocument(idxPairs...)))
-		}
-		pairs = append(pairs, "indexes", indexes)
-	}
-	return must.NotFail(types.NewDocument(pairs...))
+	return arr
 }
 
 // indexInfoToDoc renders an IndexInfo as a wire document for dumboDiff

--- a/tests/index_branch_isolation_verify_test.go
+++ b/tests/index_branch_isolation_verify_test.go
@@ -133,8 +133,13 @@ func TestIndexBranchIsolationVerify(t *testing.T) {
 		require.Len(t, statusColls, 1, "expected one collection in status")
 		assert.Equal(t, "items", statusColls[0]["name"])
 		assert.Equal(t, "modified", statusColls[0]["status"])
-		assert.Equal(t, []string{"by_name"}, mustStringSlice(t, statusColls[0]["indexesAdded"]),
-			"dumboStatus must surface by_name in indexesAdded before the commit")
+		assert.Equal(t, []string{"by_name"}, mustStringSlice(t, statusColls[0]["addedIndexes"]),
+			"dumboStatus must surface by_name in addedIndexes before the commit")
+		// modifiedIndexes and removedIndexes are always present as empty arrays.
+		assert.Empty(t, mustStringSlice(t, statusColls[0]["modifiedIndexes"]),
+			"modifiedIndexes must be an empty array when nothing modified")
+		assert.Empty(t, mustStringSlice(t, statusColls[0]["removedIndexes"]),
+			"removedIndexes must be an empty array when nothing removed")
 
 		// dumboDiff returns the full index definition (keys + direction).
 		var diffRes bson.M
@@ -142,18 +147,18 @@ func TestIndexBranchIsolationVerify(t *testing.T) {
 			"dumboDiff on am before commit must succeed")
 		diffColls := mustArrayOfMaps(t, diffRes["collections"])
 		require.Len(t, diffColls, 1, "expected one collection in diff")
-		diffIndexes := mustArrayOfMaps(t, diffColls[0]["indexes"])
-		require.Len(t, diffIndexes, 1, "expected one index in diff")
-		assert.Equal(t, "by_name", diffIndexes[0]["name"])
-		assert.Equal(t, "added", diffIndexes[0]["status"])
-		// to: must carry the full definition. from: is absent for added.
-		assert.Nil(t, diffIndexes[0]["from"])
-		toDoc := mustMap(t, diffIndexes[0]["to"])
-		assert.Equal(t, "by_name", toDoc["name"])
-		toKeys := mustArrayOfMaps(t, toDoc["keys"])
-		require.Len(t, toKeys, 1, "expected one key field")
-		assert.Equal(t, "name", toKeys[0]["field"])
-		assert.EqualValues(t, 1, toKeys[0]["direction"])
+		addedIdx := mustArrayOfMaps(t, diffColls[0]["addedIndexes"])
+		require.Len(t, addedIdx, 1, "expected one entry in addedIndexes")
+		assert.Equal(t, "by_name", addedIdx[0]["name"])
+		addedKeys := mustArrayOfMaps(t, addedIdx[0]["keys"])
+		require.Len(t, addedKeys, 1, "expected one key field")
+		assert.Equal(t, "name", addedKeys[0]["field"])
+		assert.EqualValues(t, 1, addedKeys[0]["direction"])
+		// The other two index arrays are always present and empty here.
+		assert.Empty(t, mustArrayOfMaps(t, diffColls[0]["modifiedIndexes"]),
+			"modifiedIndexes must be an empty array when nothing modified")
+		assert.Empty(t, mustArrayOfMaps(t, diffColls[0]["removedIndexes"]),
+			"removedIndexes must be an empty array when nothing removed")
 
 		dumboDBCommit(t, env, dbName+"@am", "am: create by_name", "alice <alice@acme.com>")
 
@@ -307,32 +312,37 @@ func TestIndexBranchIsolationVerify(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// dumboStatus reports the same name in indexesChanged (not added or deleted).
+		// dumboStatus reports the same name in modifiedIndexes (not added or removed).
 		var statusRes bson.M
 		require.NoError(t, mdb.RunCommand(ctx, bson.D{{Key: "dumboStatus", Value: 1}}).Decode(&statusRes))
 		statusColls := mustArrayOfMaps(t, statusRes["collections"])
 		require.Len(t, statusColls, 1)
-		assert.Nil(t, statusColls[0]["indexesAdded"], "indexesAdded must be absent")
-		assert.Nil(t, statusColls[0]["indexesDeleted"], "indexesDeleted must be absent")
-		assert.Equal(t, []string{"by_x"}, mustStringSlice(t, statusColls[0]["indexesChanged"]))
+		assert.Empty(t, mustStringSlice(t, statusColls[0]["addedIndexes"]),
+			"addedIndexes must be an empty array, not absent")
+		assert.Empty(t, mustStringSlice(t, statusColls[0]["removedIndexes"]),
+			"removedIndexes must be an empty array, not absent")
+		assert.Equal(t, []string{"by_x"}, mustStringSlice(t, statusColls[0]["modifiedIndexes"]))
 
-		// dumboDiff returns one entry with status "modified" carrying both
-		// from (age) and to (name) definitions.
+		// dumboDiff returns one entry in modifiedIndexes carrying both
+		// from (age) and to (name) definitions. addedIndexes and
+		// removedIndexes are always present and empty here.
 		var diffRes bson.M
 		require.NoError(t, mdb.RunCommand(ctx, bson.D{{Key: "dumboDiff", Value: int32(1)}}).Decode(&diffRes))
 		diffColls := mustArrayOfMaps(t, diffRes["collections"])
 		require.Len(t, diffColls, 1)
-		diffIndexes := mustArrayOfMaps(t, diffColls[0]["indexes"])
-		require.Len(t, diffIndexes, 1)
-		assert.Equal(t, "by_x", diffIndexes[0]["name"])
-		assert.Equal(t, "modified", diffIndexes[0]["status"])
+		assert.Empty(t, mustArrayOfMaps(t, diffColls[0]["addedIndexes"]))
+		assert.Empty(t, mustArrayOfMaps(t, diffColls[0]["removedIndexes"]))
 
-		fromDoc := mustMap(t, diffIndexes[0]["from"])
+		modifiedIdx := mustArrayOfMaps(t, diffColls[0]["modifiedIndexes"])
+		require.Len(t, modifiedIdx, 1)
+		fromDoc := mustMap(t, modifiedIdx[0]["from"])
+		assert.Equal(t, "by_x", fromDoc["name"])
 		fromKeys := mustArrayOfMaps(t, fromDoc["keys"])
 		require.Len(t, fromKeys, 1)
 		assert.Equal(t, "age", fromKeys[0]["field"], "from must reflect the pre-drop key")
 
-		toDoc := mustMap(t, diffIndexes[0]["to"])
+		toDoc := mustMap(t, modifiedIdx[0]["to"])
+		assert.Equal(t, "by_x", toDoc["name"])
 		toKeys := mustArrayOfMaps(t, toDoc["keys"])
 		require.Len(t, toKeys, 1)
 		assert.Equal(t, "name", toKeys[0]["field"], "to must reflect the recreated key")

--- a/tests/versioning_log_verify_test.go
+++ b/tests/versioning_log_verify_test.go
@@ -661,7 +661,8 @@ func TestLogVerify(t *testing.T) {
 		head := raw["commits"].(bson.A)[0].(bson.M)
 
 		// Stat must reflect the index-only nature: zero doc counts plus
-		// indexesAdded containing by_age.
+		// addedIndexes containing by_age. modifiedIndexes and
+		// removedIndexes are always present as empty arrays.
 		statArr, ok := head["stat"].(bson.A)
 		require.True(t, ok, "stat must be present")
 		require.Len(t, statArr, 1)
@@ -670,10 +671,16 @@ func TestLogVerify(t *testing.T) {
 		assert.EqualValues(t, 0, s["added"])
 		assert.EqualValues(t, 0, s["modified"])
 		assert.EqualValues(t, 0, s["deleted"])
-		idxAdded, ok := s["indexesAdded"].(bson.A)
-		require.True(t, ok, "indexesAdded must surface in stat")
-		require.Len(t, idxAdded, 1)
-		assert.Equal(t, "by_age", idxAdded[0])
+		addedIdx, ok := s["addedIndexes"].(bson.A)
+		require.True(t, ok, "addedIndexes must surface in stat")
+		require.Len(t, addedIdx, 1)
+		assert.Equal(t, "by_age", addedIdx[0])
+		modIdx, ok := s["modifiedIndexes"].(bson.A)
+		require.True(t, ok, "modifiedIndexes must be present as empty array")
+		assert.Empty(t, modIdx)
+		remIdx, ok := s["removedIndexes"].(bson.A)
+		require.True(t, ok, "removedIndexes must be present as empty array")
+		assert.Empty(t, remIdx)
 
 		// Patch must include the commit; before the fix it was silently
 		// dropped because the doc-diff was empty.
@@ -681,20 +688,17 @@ func TestLogVerify(t *testing.T) {
 		require.True(t, ok, "diff must be present")
 		require.Len(t, diffArr, 1, "index-only commit must appear in patch")
 		cd := diffArr[0].(bson.M)
-		indexes, ok := cd["indexes"].(bson.A)
-		require.True(t, ok, "diff[0].indexes must be present")
-		require.Len(t, indexes, 1)
-		idx := indexes[0].(bson.M)
-		assert.Equal(t, "by_age", idx["name"])
-		assert.Equal(t, "added", idx["status"])
-		assert.Nil(t, idx["from"], "no from for added index")
-		to, ok := idx["to"].(bson.M)
-		require.True(t, ok, "to must be present for added index")
-		assert.Equal(t, "by_age", to["name"])
-		toKeys := to["keys"].(bson.A)
-		require.Len(t, toKeys, 1)
-		k := toKeys[0].(bson.M)
+		diffAdded, ok := cd["addedIndexes"].(bson.A)
+		require.True(t, ok, "diff[0].addedIndexes must be present")
+		require.Len(t, diffAdded, 1)
+		addedEntry := diffAdded[0].(bson.M)
+		assert.Equal(t, "by_age", addedEntry["name"])
+		addedKeys := addedEntry["keys"].(bson.A)
+		require.Len(t, addedKeys, 1)
+		k := addedKeys[0].(bson.M)
 		assert.Equal(t, "age", k["field"])
 		assert.EqualValues(t, 1, k["direction"])
+		assert.Empty(t, cd["modifiedIndexes"].(bson.A))
+		assert.Empty(t, cd["removedIndexes"].(bson.A))
 	})
 }


### PR DESCRIPTION
The first pass on showing index deltas deviated from how we do data deltas. this aligns them