### PR TITLE
soak: bound collection size to cap aggregation memory; add local repo…

### DIFF
--- a/cmd/soak/alert.go
+++ b/cmd/soak/alert.go
@@ -16,9 +16,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -37,10 +41,13 @@ type alertMessage struct {
 
 type notifier func(ctx context.Context, msg alertMessage)
 
-func buildNotifier(alertCmd, emailFrom, emailTo, emailRegion string) notifier {
+func buildNotifier(alertCmd, emailFrom, emailTo, emailRegion, reportDir string) notifier {
 	backends := []notifier{}
 	if alertCmd != "" {
 		backends = append(backends, cmdNotifier(alertCmd))
+	}
+	if reportDir != "" {
+		backends = append(backends, fileNotifier(reportDir))
 	}
 	if emailFrom != "" && emailTo != "" {
 		backends = append(backends, sesNotifier(emailFrom, emailTo, emailRegion))
@@ -49,6 +56,37 @@ func buildNotifier(alertCmd, emailFrom, emailTo, emailRegion string) notifier {
 		for _, b := range backends {
 			b(ctx, msg)
 		}
+	}
+}
+
+// fileNotifier writes each report locally instead of mailing it,
+// for unattended runs that lack SES credentials. Each invocation
+// produces report-NNN.{txt,html,png} under dir; report-latest.*
+// always points at the most recent so a tail-friendly path exists.
+func fileNotifier(dir string) notifier {
+	var seq atomic.Int64
+	return func(ctx context.Context, msg alertMessage) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			log.Printf("report-dir: %v", err)
+			return
+		}
+		n := seq.Add(1)
+		writeFile := func(name string, data []byte) {
+			if len(data) == 0 {
+				return
+			}
+			if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+				log.Printf("report-dir write %s: %v", name, err)
+			}
+		}
+		seqName := fmt.Sprintf("report-%03d", n)
+		writeFile(seqName+".txt", []byte(msg.TextBody))
+		writeFile(seqName+".html", []byte(msg.HTMLBody))
+		writeFile(seqName+".png", msg.ChartPNG)
+		writeFile("report-latest.txt", []byte(msg.TextBody))
+		writeFile("report-latest.html", []byte(msg.HTMLBody))
+		writeFile("report-latest.png", msg.ChartPNG)
+		log.Printf("report written: %s/%s.{txt,html,png}", dir, seqName)
 	}
 }
 

--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -66,25 +66,35 @@ func main() {
 		txnWorkers     = flag.Int("workers-txn", 1, "multi-op session.WithTransaction workers")
 		opsInterval    = flag.Duration("ops-interval", time.Second, "base delay between ops; heavier worker types scale this up internally")
 		sessionDelay   = flag.Duration("session-delay", 250*time.Millisecond, "delay between cycles on each session-churn worker")
+		collectionCap  = flag.Int("collection-cap", 100000, "hold the shared collection near this many docs via a trim worker; 0 disables trimming and lets it grow unbounded")
+		trimInterval   = flag.Duration("trim-interval", time.Second, "how often the trim worker checks the collection size and deletes the overflow")
 
 		// Detection.
 		slopeWindow      = flag.Duration("slope-window", 6*time.Hour, "rolling window over which the slope is computed")
 		slopeThresholdMB = flag.Float64("slope-threshold-mb-per-hour", 1.0, "MB/hour of sustained growth that triggers an alert")
 		cooldown         = flag.Duration("cooldown", 24*time.Hour, "minimum delay between alerts")
 
-		// Email alerting (required: the soak has no value running unattended without it).
-		emailFrom = flag.String("email-from", "", "SES verified From address (required)")
-		emailTo   = flag.String("email-to", "", "alert recipient(s), comma-separated (required)")
+		// Email alerting via SES.
+		emailFrom = flag.String("email-from", "", "SES verified From address")
+		emailTo   = flag.String("email-to", "", "alert recipient(s), comma-separated")
 		emailRegn = flag.String("email-region", "", "AWS region for SES; default chain region used when blank")
 		emailSubj = flag.String("email-subject", "dumbodb soak alert", "Subject line for SES alerts")
+
+		// Local report sink for runs without SES credentials. Writes each
+		// alert/summary report (text, html, png) into this directory.
+		reportDir = flag.String("report-dir", "", "if set, write each report locally instead of (or in addition to) mailing it")
 
 		// Optional secondary alert channel (e.g. local mailx, ntfy, curl-to-webhook).
 		alertCmd = flag.String("alert-cmd", "", "shell command to run on each alert in addition to email; body on stdin")
 	)
 	flag.Parse()
 
-	if *emailFrom == "" || *emailTo == "" {
-		log.Fatal("-email-from and -email-to are required")
+	// The soak has no value running unattended without a sink for its
+	// reports, but any one of SES, a local report dir, or an alert
+	// command satisfies that.
+	emailEnabled := *emailFrom != "" && *emailTo != ""
+	if !emailEnabled && *reportDir == "" && *alertCmd == "" {
+		log.Fatal("configure at least one report sink: -email-from/-email-to, -report-dir, or -alert-cmd")
 	}
 	if (*attachAddr == "") != (*attachPid == 0) {
 		log.Fatal("-attach-addr and -attach-pid must be set together (or not at all)")
@@ -113,7 +123,7 @@ func main() {
 	}
 	defer writer.Close()
 
-	notify := buildNotifier(*alertCmd, *emailFrom, *emailTo, *emailRegn)
+	notify := buildNotifier(*alertCmd, *emailFrom, *emailTo, *emailRegn, *reportDir)
 	detector := newSlopeDetector(*slopeWindow, *slopeThresholdMB, *cooldown)
 
 	wl, err := startWorkload(ctx, workloadConfig{
@@ -127,6 +137,8 @@ func main() {
 		TxnWorkers:     *txnWorkers,
 		SessionDelay:   *sessionDelay,
 		OpsInterval:    *opsInterval,
+		CollectionCap:  *collectionCap,
+		TrimInterval:   *trimInterval,
 	})
 	if err != nil {
 		log.Fatalf("starting workload: %v", err)

--- a/cmd/soak/workers.go
+++ b/cmd/soak/workers.go
@@ -154,8 +154,11 @@ func (w *workload) runBulkWorker(ctx context.Context, uri, collName string, work
 			w.errors.Add(1)
 		}
 		w.cycles.Add(1)
-		// Bulk inserts are heavier; back off proportionally.
-		if !sleep(ctx, opsInterval*5) {
+		// One batch per opsInterval. With the default batch size and
+		// interval this drives roughly 100 inserts/sec into the shared
+		// collection, fast enough to warm it to the trim cap within
+		// ~30 min.
+		if !sleep(ctx, opsInterval) {
 			return
 		}
 	}
@@ -398,6 +401,100 @@ func (w *workload) runTxnWorker(ctx context.Context, uri, collName string, worke
 			return
 		}
 	}
+}
+
+// trimBaseRatePerSec is the steady-state deletion rate (docs/sec) the
+// trim worker targets at the cap. It is matched to the bulk worker's
+// approximate insert rate so deletions balance inserts once the
+// collection is full. It only shapes the approach to the cap; the
+// overflow term in trimBudget enforces the cap for any actual insert
+// rate.
+const trimBaseRatePerSec = 100.0
+
+// runTrimWorker holds the shared collection near cap by deleting
+// documents at a rate that ramps with how full the collection is:
+// nothing while it fills (so warmup stays fast), rising to the insert
+// rate as it nears cap, and the full overflow above cap. This converts
+// the otherwise monotonically growing collection into a steady-state
+// population so aggregation memory plateaus instead of growing without
+// bound. A cap of 0 disables trimming.
+func (w *workload) runTrimWorker(ctx context.Context, uri, collName string, cap int, interval time.Duration) {
+	defer w.wg.Done()
+	if cap <= 0 {
+		return
+	}
+	client, err := mongo.Connect(options.Client().ApplyURI(uri))
+	if err != nil {
+		w.errors.Add(1)
+		return
+	}
+	defer client.Disconnect(context.Background())
+	coll := client.Database("soak").Collection(collName)
+	lowWater := cap / 2
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		count, err := coll.EstimatedDocumentCount(cctx)
+		if err != nil {
+			w.errors.Add(1)
+		} else if del := trimBudget(int(count), cap, lowWater, interval); del > 0 {
+			if err := deleteOldest(cctx, coll, del); err != nil {
+				w.errors.Add(1)
+			}
+		}
+		cancel()
+		w.cycles.Add(1)
+		if !sleep(ctx, interval) {
+			return
+		}
+	}
+}
+
+// trimBudget returns how many documents to delete this tick. It is 0
+// below lowWater, ramps linearly from 0 at lowWater to one interval's
+// worth of trimBaseRatePerSec at cap, and adds the full overflow above
+// cap so the collection is pulled back to cap within a tick or two
+// regardless of how fast inserts run.
+func trimBudget(count, cap, lowWater int, interval time.Duration) int {
+	if count <= lowWater {
+		return 0
+	}
+	base := trimBaseRatePerSec * interval.Seconds()
+	if count <= cap {
+		frac := float64(count-lowWater) / float64(cap-lowWater)
+		return int(frac * base)
+	}
+	return (count - cap) + int(base)
+}
+
+// deleteOldest deletes n documents in collection key order. Mongo's
+// delete command cannot limit a multi-delete to n, so we enumerate n
+// _ids first (projection-only find) and delete them in one DeleteMany.
+// Key order trims the oldest bulk batches first, since their _ids are
+// monotonic in batch sequence.
+func deleteOldest(ctx context.Context, coll *mongo.Collection, n int) error {
+	cur, err := coll.Find(ctx, bson.M{}, options.Find().SetLimit(int64(n)).SetProjection(bson.M{"_id": 1}))
+	if err != nil {
+		return err
+	}
+	var ids []any
+	for cur.Next(ctx) {
+		var d struct {
+			ID any `bson:"_id"`
+		}
+		if err := cur.Decode(&d); err == nil {
+			ids = append(ids, d.ID)
+		}
+	}
+	cur.Close(ctx)
+	if len(ids) == 0 {
+		return nil
+	}
+	_, err = coll.DeleteMany(ctx, bson.M{"_id": bson.M{"$in": ids}})
+	return err
 }
 
 // sleep returns false if ctx fires before the delay elapses, so the

--- a/cmd/soak/workload.go
+++ b/cmd/soak/workload.go
@@ -44,6 +44,8 @@ type workloadConfig struct {
 	TxnWorkers     int
 	SessionDelay   time.Duration
 	OpsInterval    time.Duration
+	CollectionCap  int
+	TrimInterval   time.Duration
 }
 
 func (w *workload) cycleCount() int64 { return w.cycles.Load() }
@@ -92,6 +94,10 @@ func startWorkload(parent context.Context, cfg workloadConfig) (*workload, error
 	for i := 0; i < cfg.TxnWorkers; i++ {
 		w.wg.Add(1)
 		go w.runTxnWorker(ctx, cfg.URI, collName, i, cfg.OpsInterval)
+	}
+	if cfg.CollectionCap > 0 {
+		w.wg.Add(1)
+		go w.runTrimWorker(ctx, cfg.URI, collName, cfg.CollectionCap, cfg.TrimInterval)
 	}
 	return w, nil
 }


### PR DESCRIPTION
…rt sink

The shared soak collection grew monotonically because the bulk InsertMany workers never deleted, so the $group aggregation stage buffered an ever-larger input ([]*types.Document for the whole collection) and live heap grew without bound on long runs. Verified via a 2.5h soak: post-GC heap reached 4.4GB with 87% rooted in groupDocuments, climbing steadily past the 1hr mark.

Add a feedback-controlled trim worker (-collection-cap, default 100000) that reads the collection size each -trim-interval and deletes the overflow: nothing below cap/2, ramping to the insert rate as it nears the cap, and the full overflow above it (self-correcting to any insert rate). Raise the bulk insert rate (~25 -> ~100 docs/sec) so the collection warms to the cap within ~30 min. At steady state deletions balance inserts. Validated at cap=20000: both the collection count and RSS plateau at the cap instead of growing.

Also make SES email optional and add -report-dir, which writes each report (text/html/png) to a local directory, so the soak can run and be inspected without SES credentials. At least one of email, -report-dir, or -alert-cmd is now required.