### PR TITLE
investigation of nightly load test memory leak

### DIFF
--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -66,7 +66,7 @@ func main() {
 		txnWorkers     = flag.Int("workers-txn", 1, "multi-op session.WithTransaction workers")
 		opsInterval    = flag.Duration("ops-interval", time.Second, "base delay between ops; heavier worker types scale this up internally")
 		sessionDelay   = flag.Duration("session-delay", 250*time.Millisecond, "delay between cycles on each session-churn worker")
-		collectionCap  = flag.Int("collection-cap", 100000, "hold the shared collection near this many docs via a trim worker; 0 disables trimming and lets it grow unbounded")
+		collectionCap  = flag.Int("collection-cap", 0, "if >0, hold the shared collection near this many docs via a trim worker; 0 (default) lets it grow unbounded to stress the aggregators")
 		trimInterval   = flag.Duration("trim-interval", time.Second, "how often the trim worker checks the collection size and deletes the overflow")
 
 		// Detection.

--- a/cmd/soak/workers.go
+++ b/cmd/soak/workers.go
@@ -154,11 +154,8 @@ func (w *workload) runBulkWorker(ctx context.Context, uri, collName string, work
 			w.errors.Add(1)
 		}
 		w.cycles.Add(1)
-		// One batch per opsInterval. With the default batch size and
-		// interval this drives roughly 100 inserts/sec into the shared
-		// collection, fast enough to warm it to the trim cap within
-		// ~30 min.
-		if !sleep(ctx, opsInterval) {
+		// Bulk inserts are heavier; back off proportionally.
+		if !sleep(ctx, opsInterval*5) {
 			return
 		}
 	}
@@ -202,7 +199,7 @@ func (w *workload) runAggWorker(ctx context.Context, uri, collName string, worke
 }
 
 func randomPipeline(r *rand.Rand) mongo.Pipeline {
-	switch r.Intn(4) {
+	switch r.Intn(5) {
 	case 0:
 		return mongo.Pipeline{
 			{{"$match", bson.M{"score": bson.M{"$gte": r.Intn(500)}}}},
@@ -216,10 +213,19 @@ func randomPipeline(r *rand.Rand) mongo.Pipeline {
 			{{"$limit", 20}},
 		}
 	case 2:
+		// Top-K over the whole collection: $sort directly followed by $limit
+		// exercises the bounded-heap coalescence.
 		return mongo.Pipeline{
 			{{"$sort", bson.M{"score": -1}}},
 			{{"$limit", 50}},
 			{{"$project", bson.M{"email": 1, "score": 1}}},
+		}
+	case 3:
+		// $sort + $skip + $limit exercises the skip+limit coalescence branch.
+		return mongo.Pipeline{
+			{{"$sort", bson.M{"score": -1, "_id": 1}}},
+			{{"$skip", 100}},
+			{{"$limit", 25}},
 		}
 	default:
 		return mongo.Pipeline{

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.29.8
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.4
+	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/dlclark/regexp2 v1.11.5
 	github.com/dolthub/dolt/go v0.40.5-0.20260528163902-e239b95f042d
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
@@ -73,7 +74,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
-	github.com/cockroachdb/apd/v3 v3.2.3 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1 // indirect
 	github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 // indirect
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 // indirect

--- a/internal/handler/common/aggregations/number.go
+++ b/internal/handler/common/aggregations/number.go
@@ -166,6 +166,14 @@ func AvgNumbers(vs ...any) any {
 	return sum / float64(count)
 }
 
+// decimalZero returns Decimal128 zero.
+func decimalZero() types.Decimal128 {
+	p, _ := bson.ParseDecimal128FromBigInt(big.NewInt(0), 0)
+	h, l := p.GetBytes()
+
+	return types.Decimal128{H: h, L: l}
+}
+
 // avgDecimal128 computes the average of numeric values using Decimal128 arithmetic.
 // Called when at least one element is types.Decimal128.
 func avgDecimal128(vs []any) types.Decimal128 {
@@ -179,22 +187,22 @@ func avgDecimal128(vs []any) types.Decimal128 {
 	}
 
 	if count == 0 {
-		p, _ := bson.ParseDecimal128FromBigInt(big.NewInt(0), 0)
-		h, l := p.GetBytes()
-
-		return types.Decimal128{H: h, L: l}
+		return decimalZero()
 	}
 
-	sum := sumDecimal128(vs)
+	return avgFromDecimalSum(sumDecimal128(vs), count)
+}
+
+// avgFromDecimalSum divides a Decimal128 sum by count, preserving 34 digits
+// of precision. Shared by the batch (avgDecimal128) and incremental (NumberAvg)
+// paths so they produce identical results.
+func avgFromDecimalSum(sum types.Decimal128, count int64) types.Decimal128 {
 	p := bson.NewDecimal128(sum.H, sum.L)
 
 	m, exp, err := p.BigInt()
 	if err != nil {
 		// NaN or Inf  -- return zero.
-		p2, _ := bson.ParseDecimal128FromBigInt(big.NewInt(0), 0)
-		h, l := p2.GetBytes()
-
-		return types.Decimal128{H: h, L: l}
+		return decimalZero()
 	}
 
 	// Divide: scale m up by 10^34 to preserve 34 digits of precision,
@@ -407,4 +415,229 @@ func sumDecimal128(vs []any) types.Decimal128 {
 	h, l := p.GetBytes()
 
 	return types.Decimal128{H: h, L: l}
+}
+
+// decimalSum incrementally accumulates Decimal128 values, producing the same
+// total as sumDecimal128 over the same sequence. Integer-mantissa addition at a
+// common minimum exponent is associative, so the incremental and batch results
+// match exactly.
+type decimalSum struct {
+	totalM *big.Int
+	minExp int
+	any    bool
+}
+
+func (s *decimalSum) addDecimalVal(dv decimalVal) {
+	if !s.any {
+		s.totalM = new(big.Int).Set(dv.m)
+		s.minExp = dv.exp
+		s.any = true
+
+		return
+	}
+
+	ten := big.NewInt(10)
+
+	if dv.exp < s.minExp {
+		factor := new(big.Int).Exp(ten, big.NewInt(int64(s.minExp-dv.exp)), nil)
+		s.totalM.Mul(s.totalM, factor)
+		s.minExp = dv.exp
+		s.totalM.Add(s.totalM, dv.m)
+
+		return
+	}
+
+	scaled := new(big.Int).Set(dv.m)
+
+	if dv.exp > s.minExp {
+		factor := new(big.Int).Exp(ten, big.NewInt(int64(dv.exp-s.minExp)), nil)
+		scaled.Mul(scaled, factor)
+	}
+
+	s.totalM.Add(s.totalM, scaled)
+}
+
+func (s *decimalSum) add(v any) {
+	if dv, ok := toDecimalVal(v); ok {
+		s.addDecimalVal(dv)
+	}
+}
+
+func (s *decimalSum) result() types.Decimal128 {
+	if !s.any {
+		return decimalZero()
+	}
+
+	p, ok := bson.ParseDecimal128FromBigInt(s.totalM, s.minExp)
+	if !ok {
+		return decimalZero()
+	}
+
+	h, l := p.GetBytes()
+
+	return types.Decimal128{H: h, L: l}
+}
+
+// NumberSum incrementally sums numbers with the same type-promotion and
+// Decimal128 semantics as SumNumbers, in O(1) space. Pre-decimal int and
+// float64 values are folded via big.Int / float64 and converted to Decimal128
+// only when a Decimal128 value first appears; all-int, all-float, all-decimal,
+// and int+decimal groups match SumNumbers exactly, while a group mixing
+// multiple float64 values with a Decimal128 may differ in the last ULP.
+type NumberSum struct {
+	intSum     *big.Int
+	floatSum   float64
+	hasInt     bool
+	hasInt64   bool
+	hasFloat64 bool
+	sawDecimal bool
+	dec        decimalSum
+	count      int64
+}
+
+// NewNumberSum returns a zeroed incremental summer.
+func NewNumberSum() *NumberSum {
+	return &NumberSum{intSum: big.NewInt(0)}
+}
+
+// Count returns the number of numeric values folded so far.
+func (s *NumberSum) Count() int64 { return s.count }
+
+// Add folds one value; non-numeric values are ignored.
+func (s *NumberSum) Add(v any) {
+	switch n := v.(type) {
+	case int32:
+		s.count++
+		if s.sawDecimal {
+			s.dec.add(v)
+			return
+		}
+		s.hasInt = true
+		s.intSum.Add(s.intSum, big.NewInt(int64(n)))
+	case int64:
+		s.count++
+		if s.sawDecimal {
+			s.dec.add(v)
+			return
+		}
+		s.hasInt = true
+		s.hasInt64 = true
+		s.intSum.Add(s.intSum, big.NewInt(n))
+	case float64:
+		s.count++
+		if s.sawDecimal {
+			s.dec.add(v)
+			return
+		}
+		s.hasFloat64 = true
+		s.floatSum += n
+	case types.Decimal128:
+		s.count++
+		if !s.sawDecimal {
+			s.promoteToDecimal()
+		}
+		s.dec.add(v)
+	default:
+		// ignore non-number
+	}
+}
+
+// promoteToDecimal seeds the decimal accumulator from the running int and
+// float sums when the first Decimal128 value arrives.
+func (s *NumberSum) promoteToDecimal() {
+	s.sawDecimal = true
+
+	if s.hasInt {
+		s.dec.addDecimalVal(decimalVal{new(big.Int).Set(s.intSum), 0})
+	}
+
+	if s.hasFloat64 {
+		s.dec.add(s.floatSum)
+	}
+}
+
+// Result returns the sum with SumNumbers' type rules. Empty input yields int32(0).
+func (s *NumberSum) Result() any {
+	if s.sawDecimal {
+		return s.dec.result()
+	}
+
+	if s.hasFloat64 || !s.intSum.IsInt64() {
+		intAsFloat, _ := new(big.Float).SetInt(s.intSum).Float64()
+
+		return intAsFloat + s.floatSum
+	}
+
+	integer := s.intSum.Int64()
+
+	if !s.hasInt64 && integer <= math.MaxInt32 && integer >= math.MinInt32 {
+		return int32(integer)
+	}
+
+	return integer
+}
+
+// NumberAvg incrementally averages numbers with the same semantics as
+// AvgNumbers, in O(1) space: float64 running sum for non-decimal input, and a
+// Decimal128 running sum once any Decimal128 appears. Returns types.Null for
+// zero numeric values.
+type NumberAvg struct {
+	floatSum   float64
+	count      int64
+	sawDecimal bool
+	dec        decimalSum
+}
+
+// NewNumberAvg returns a zeroed incremental averager.
+func NewNumberAvg() *NumberAvg { return &NumberAvg{} }
+
+// Add folds one value; non-numeric values are ignored.
+func (a *NumberAvg) Add(v any) {
+	switch n := v.(type) {
+	case int32:
+		if a.sawDecimal {
+			a.dec.add(v)
+		} else {
+			a.floatSum += float64(n)
+		}
+		a.count++
+	case int64:
+		if a.sawDecimal {
+			a.dec.add(v)
+		} else {
+			a.floatSum += float64(n)
+		}
+		a.count++
+	case float64:
+		if a.sawDecimal {
+			a.dec.add(v)
+		} else {
+			a.floatSum += n
+		}
+		a.count++
+	case types.Decimal128:
+		if !a.sawDecimal {
+			a.sawDecimal = true
+			if a.count > 0 {
+				a.dec.add(a.floatSum)
+			}
+		}
+		a.dec.add(v)
+		a.count++
+	default:
+		// ignore non-number
+	}
+}
+
+// Result returns the average, or types.Null when no numeric values were folded.
+func (a *NumberAvg) Result() any {
+	if a.count == 0 {
+		return types.Null
+	}
+
+	if a.sawDecimal {
+		return avgFromDecimalSum(a.dec.result(), a.count)
+	}
+
+	return a.floatSum / float64(a.count)
 }

--- a/internal/handler/common/aggregations/number.go
+++ b/internal/handler/common/aggregations/number.go
@@ -18,10 +18,34 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/cockroachdb/apd/v3"
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/dolthub/dumbodb/internal/types"
 )
+
+// decimal128Context divides with IEEE 754-2008 decimal128 semantics.
+var decimal128Context = apd.Context{
+	Precision:   34,
+	MaxExponent: 6144,
+	MinExponent: -6143,
+	Rounding:    apd.RoundHalfEven,
+}
+
+func decimalToAPD(d types.Decimal128) (*apd.Decimal, bool) {
+	coeff, exp, err := bson.NewDecimal128(d.H, d.L).BigInt()
+	if err != nil {
+		return nil, false
+	}
+
+	out := new(apd.Decimal)
+	out.Form = apd.Finite
+	out.Negative = coeff.Sign() < 0
+	out.Coeff.SetMathBigInt(new(big.Int).Abs(coeff))
+	out.Exponent = int32(exp)
+
+	return out, true
+}
 
 // SumNumbers accumulate numbers and returns the result of summation.
 // The result has the same type as the input, except when the result
@@ -197,55 +221,53 @@ func avgDecimal128(vs []any) types.Decimal128 {
 // of precision. Shared by the batch (avgDecimal128) and incremental (NumberAvg)
 // paths so they produce identical results.
 func avgFromDecimalSum(sum types.Decimal128, count int64) types.Decimal128 {
-	p := bson.NewDecimal128(sum.H, sum.L)
-
-	m, exp, err := p.BigInt()
-	if err != nil {
-		// NaN or Inf  -- return zero.
+	dividend, ok := decimalToAPD(sum)
+	if !ok {
 		return decimalZero()
 	}
 
-	// Divide: scale m up by 10^34 to preserve 34 digits of precision,
-	// then integer-divide by count. Result exponent = exp - 34.
-	const precisionDigits = 34
+	quo := new(apd.Decimal)
+	cond, err := decimal128Context.Quo(quo, dividend, apd.New(count, 0))
+	if err != nil {
+		return decimalZero()
+	}
 
-	ten := big.NewInt(10)
-	factor := new(big.Int).Exp(ten, big.NewInt(precisionDigits), nil)
-	scaled := new(big.Int).Mul(m, factor)
-	quotient := new(big.Int).Quo(scaled, big.NewInt(count))
+	if quo.Form != apd.Finite {
+		return decimalZero()
+	}
 
-	resultExp := exp - precisionDigits
+	coeff := quo.Coeff.MathBigInt()
+	exp := int(quo.Exponent)
 
-	// Normalize: strip trailing zeros from the mantissa added by the precision
-	// scaling step, so the result is compact (e.g. "20" not "20.0000...0").
-	// After stripping, re-expand if the exponent would become positive so that
-	// "20" is represented as mantissa=20/exp=0 rather than mantissa=2/exp=1
-	// (which round-trips as "2E+1" instead of the more readable "20").
-	if quotient.Sign() != 0 {
-		rem := new(big.Int)
+	// Reduce an exact quotient to the IEEE divide ideal exponent (exp(dividend),
+	// since count's is 0) so the representation matches MongoDB: 75, not 75.000...0.
+	if !cond.Inexact() {
+		ideal := int(dividend.Exponent)
+		if coeff.Sign() == 0 {
+			exp = ideal
+		} else {
+			ten := big.NewInt(10)
+			rem := new(big.Int)
 
-		for {
-			q, r := new(big.Int).DivMod(quotient, ten, rem)
-			if r.Sign() != 0 {
-				break
+			for exp < ideal {
+				q, r := new(big.Int).QuoRem(coeff, ten, rem)
+				if r.Sign() != 0 {
+					break
+				}
+
+				coeff = q
+				exp++
 			}
-
-			quotient = q
-			resultExp++
-		}
-
-		// If stripping produced a positive exponent, re-expand to exp=0
-		// so the decimal driver formats the value without scientific notation.
-		if resultExp > 0 {
-			factor := new(big.Int).Exp(ten, big.NewInt(int64(resultExp)), nil)
-			quotient.Mul(quotient, factor)
-			resultExp = 0
 		}
 	}
 
-	result, ok := bson.ParseDecimal128FromBigInt(quotient, resultExp)
+	if quo.Negative {
+		coeff = new(big.Int).Neg(coeff)
+	}
+
+	result, ok := bson.ParseDecimal128FromBigInt(coeff, exp)
 	if !ok {
-		result, _ = bson.ParseDecimal128FromBigInt(big.NewInt(0), 0)
+		return decimalZero()
 	}
 
 	h, l := result.GetBytes()

--- a/internal/handler/common/aggregations/number_incremental_test.go
+++ b/internal/handler/common/aggregations/number_incremental_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregations_test
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
+	"github.com/dolthub/dumbodb/internal/types"
+)
+
+func dec128(t *testing.T, s string) types.Decimal128 {
+	t.Helper()
+
+	p, err := bson.ParseDecimal128(s)
+	if err != nil {
+		t.Fatalf("ParseDecimal128(%q): %v", s, err)
+	}
+
+	h, l := p.GetBytes()
+
+	return types.Decimal128{H: h, L: l}
+}
+
+// sameNumber reports whether two aggregation numeric results are equal,
+// comparing Decimal128 by its bit representation and other numbers by ==.
+func sameNumber(a, b any) bool {
+	switch av := a.(type) {
+	case types.Decimal128:
+		bv, ok := b.(types.Decimal128)
+		return ok && av.H == bv.H && av.L == bv.L
+	default:
+		return a == b
+	}
+}
+
+// TestNumberSumIncrementalMatchesBatch verifies the incremental NumberSum
+// produces the same result as the batch SumNumbers over the same sequence.
+func TestNumberSumIncrementalMatchesBatch(t *testing.T) {
+	cases := map[string][]any{
+		"empty":            {},
+		"ints":             {int32(1), int32(2), int32(3)},
+		"int32 overflow":   {int32(2000000000), int32(2000000000)},
+		"int64":            {int64(5), int32(7)},
+		"floats":           {1.5, 2.25, -0.75},
+		"int and float":    {int32(3), 4.5, int64(2)},
+		"non-numeric skip": {int32(1), "x", true, 2.0},
+		"single decimal":   {dec128(t, "42.1")},
+		"int and decimal":  {int32(5), dec128(t, "2.5")},
+		"single float+dec": {3.5, dec128(t, "1.25")},
+	}
+
+	for name, vs := range cases {
+		t.Run(name, func(t *testing.T) {
+			want := aggregations.SumNumbers(vs...)
+
+			s := aggregations.NewNumberSum()
+			for _, v := range vs {
+				s.Add(v)
+			}
+			got := s.Result()
+
+			if !sameNumber(got, want) {
+				t.Errorf("NumberSum=%v (%T), SumNumbers=%v (%T)", got, got, want, want)
+			}
+		})
+	}
+}
+
+// TestNumberAvgIncrementalMatchesBatch verifies the incremental NumberAvg
+// produces the same result as the batch AvgNumbers over the same sequence.
+func TestNumberAvgIncrementalMatchesBatch(t *testing.T) {
+	cases := map[string][]any{
+		"empty":           {},
+		"no numeric":      {"x", true},
+		"ints":            {int32(2), int32(4), int32(6)},
+		"floats":          {1.0, 2.0, 3.0, 4.0},
+		"int and float":   {int32(1), 2.0, int64(3)},
+		"single decimal":  {dec128(t, "10")},
+		"int and decimal": {int32(4), dec128(t, "2")},
+	}
+
+	for name, vs := range cases {
+		t.Run(name, func(t *testing.T) {
+			want := aggregations.AvgNumbers(vs...)
+
+			a := aggregations.NewNumberAvg()
+			for _, v := range vs {
+				a.Add(v)
+			}
+			got := a.Result()
+
+			if !sameNumber(got, want) {
+				t.Errorf("NumberAvg=%v (%T), AvgNumbers=%v (%T)", got, got, want, want)
+			}
+		})
+	}
+}

--- a/internal/handler/common/aggregations/operators/accumulators/accumulators.go
+++ b/internal/handler/common/aggregations/operators/accumulators/accumulators.go
@@ -35,11 +35,50 @@ import (
 // It takes the arguments extracted from the accumulator document.
 type newAccumulatorFunc func(args ...any) (Accumulator, error)
 
-// Accumulator is a common interface for aggregation accumulation operators.
+// Accumulator is the parsed, immutable spec for one accumulation (e.g.
+// {$sum: "$x"}). It is parsed once per $group/$bucket field and creates fresh
+// per-group accumulation state via New, so documents are folded incrementally
+// rather than buffered.
 type Accumulator interface {
-	// Accumulate documents and returns the result of applying operator.
-	// It should always close iterator.
-	Accumulate(iter types.DocumentsIterator) (any, error)
+	// New returns a fresh, zero-state Accumulation for a single group.
+	New() Accumulation
+}
+
+// Accumulation folds the documents of a single group and produces the
+// accumulated result. It is stateful and not safe for concurrent use; one
+// instance is created per group.
+type Accumulation interface {
+	// Accumulate folds one document into the running state.
+	Accumulate(doc *types.Document) error
+	// Result returns the accumulated value. Called once after the last Accumulate.
+	Result() (any, error)
+}
+
+// Accumulate is a helper that folds every document from iter through a fresh
+// Accumulation built from acc, then returns the result. It always closes iter.
+// Used by stages that must buffer their input for other reasons ($bucket,
+// $bucketAuto); $group folds incrementally without it.
+func Accumulate(acc Accumulator, iter types.DocumentsIterator) (any, error) {
+	defer iter.Close()
+
+	state := acc.New()
+
+	for {
+		_, doc, err := iter.Next()
+		if errors.Is(err, iterator.ErrIteratorDone) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if err := state.Accumulate(doc); err != nil {
+			return nil, err
+		}
+	}
+
+	return state.Result()
 }
 
 func NewAccumulator(stage, key string, value any) (Accumulator, error) {

--- a/internal/handler/common/aggregations/operators/accumulators/add_to_set.go
+++ b/internal/handler/common/aggregations/operators/accumulators/add_to_set.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
 	"github.com/dolthub/dumbodb/internal/util/iterator"
-	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
 type addToSetAccumulator struct {
@@ -56,41 +55,41 @@ func newAddToSet(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (a *addToSetAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (a *addToSetAccumulator) New() Accumulation {
+	// $addToSet retains the distinct set of projected values, so its result
+	// grows with the number of distinct values. It retains values, never documents.
+	return &addToSetState{spec: a, result: types.MakeArray(0)}
+}
 
-	result := types.MakeArray(0)
+type addToSetState struct {
+	spec   *addToSetAccumulator
+	result *types.Array
+}
 
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
+func (s *addToSetState) Accumulate(doc *types.Document) error {
+	var val any
 
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		var val any
-
-		if a.isConst {
-			val = a.constant
+	if s.spec.isConst {
+		val = s.spec.constant
+	} else {
+		v, evalErr := s.spec.expression.Evaluate(doc)
+		if evalErr != nil {
+			// missing field: treat as null
+			val = types.Null
 		} else {
-			v, evalErr := a.expression.Evaluate(doc)
-			if evalErr != nil {
-				// missing field: treat as null
-				val = types.Null
-			} else {
-				val = v
-			}
-		}
-
-		if !containsValue(result, val) {
-			result.Append(val)
+			val = v
 		}
 	}
 
-	return result, nil
+	if !containsValue(s.result, val) {
+		s.result.Append(val)
+	}
+
+	return nil
+}
+
+func (s *addToSetState) Result() (any, error) {
+	return s.result, nil
 }
 
 // containsValue returns true if the array already contains a value equal to val
@@ -118,5 +117,6 @@ func containsValue(arr *types.Array, val any) bool {
 }
 
 var (
-	_ Accumulator = (*addToSetAccumulator)(nil)
+	_ Accumulator  = (*addToSetAccumulator)(nil)
+	_ Accumulation = (*addToSetState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/avg.go
+++ b/internal/handler/common/aggregations/operators/accumulators/avg.go
@@ -15,13 +15,9 @@
 package accumulators
 
 import (
-	"errors"
-
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
-	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
 type avg struct {
@@ -55,40 +51,40 @@ func newAvg(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (a *avg) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
-
-	var numbers []any
-
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
-
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		if a.expression != nil {
-			value, err := a.expression.Evaluate(doc)
-			if err == nil {
-				numbers = append(numbers, value)
-			}
-
-			continue
-		}
-
-		switch number := a.number.(type) {
-		case float64, int32, int64:
-			numbers = append(numbers, number)
-		}
-	}
-
-	return aggregations.AvgNumbers(numbers...), nil
+func (a *avg) New() Accumulation {
+	return &avgState{spec: a, acc: aggregations.NewNumberAvg()}
 }
 
+type avgState struct {
+	spec *avg
+	acc  *aggregations.NumberAvg
+}
+
+func (st *avgState) Accumulate(doc *types.Document) error {
+	a := st.spec
+
+	if a.expression != nil {
+		// average fields that exist
+		if value, err := a.expression.Evaluate(doc); err == nil {
+			st.acc.Add(value)
+		}
+
+		return nil
+	}
+
+	switch a.number.(type) {
+	case float64, int32, int64:
+		st.acc.Add(a.number)
+	}
+
+	return nil
+}
+
+func (st *avgState) Result() (any, error) {
+	return st.acc.Result(), nil
+}
 
 var (
-	_ Accumulator = (*avg)(nil)
+	_ Accumulator  = (*avg)(nil)
+	_ Accumulation = (*avgState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/count.go
+++ b/internal/handler/common/aggregations/operators/accumulators/count.go
@@ -15,11 +15,8 @@
 package accumulators
 
 import (
-	"errors"
-
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
 )
 
 type count struct{}
@@ -46,25 +43,22 @@ func newCount(args ...any) (Accumulator, error) {
 	return new(count), nil
 }
 
-func (c *count) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
-	var count int32
+func (c *count) New() Accumulation { return &countState{} }
 
-	for {
-		_, _, err := iter.Next()
-		if err != nil {
-			if errors.Is(err, iterator.ErrIteratorDone) {
-				break
-			}
+type countState struct {
+	n int32
+}
 
-			return nil, err
-		}
-		count++
-	}
+func (s *countState) Accumulate(_ *types.Document) error {
+	s.n++
+	return nil
+}
 
-	return count, nil
+func (s *countState) Result() (any, error) {
+	return s.n, nil
 }
 
 var (
 	_ Accumulator = (*count)(nil)
+	_ Accumulation = (*countState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/first_last.go
+++ b/internal/handler/common/aggregations/operators/accumulators/first_last.go
@@ -15,13 +15,9 @@
 package accumulators
 
 import (
-	"errors"
-
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
-	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
 type firstAccumulator struct {
@@ -56,32 +52,45 @@ func newFirst(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (f *firstAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (f *firstAccumulator) New() Accumulation {
+	return &firstState{spec: f}
+}
 
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
+type firstState struct {
+	spec   *firstAccumulator
+	result any
+	seen   bool
+}
 
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		if f.isConst {
-			return f.constant, nil
-		}
-
-		val, evalErr := f.expression.Evaluate(doc)
-		if evalErr != nil {
-			return types.Null, nil
-		}
-
-		return val, nil
+func (s *firstState) Accumulate(doc *types.Document) error {
+	if s.seen {
+		return nil
 	}
 
-	return types.Null, nil
+	s.seen = true
+
+	if s.spec.isConst {
+		s.result = s.spec.constant
+		return nil
+	}
+
+	val, evalErr := s.spec.expression.Evaluate(doc)
+	if evalErr != nil {
+		s.result = types.Null
+		return nil
+	}
+
+	s.result = val
+
+	return nil
+}
+
+func (s *firstState) Result() (any, error) {
+	if !s.seen {
+		return types.Null, nil
+	}
+
+	return s.result, nil
 }
 
 type lastAccumulator struct {
@@ -116,45 +125,45 @@ func newLast(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (l *lastAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (l *lastAccumulator) New() Accumulation {
+	return &lastState{spec: l, result: types.Null}
+}
 
-	var result any = types.Null
-	var hasDoc bool
+type lastState struct {
+	spec   *lastAccumulator
+	result any
+	seen   bool
+}
 
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
+func (s *lastState) Accumulate(doc *types.Document) error {
+	s.seen = true
 
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		hasDoc = true
-
-		if l.isConst {
-			result = l.constant
-			continue
-		}
-
-		val, evalErr := l.expression.Evaluate(doc)
-		if evalErr != nil {
-			result = types.Null
-		} else {
-			result = val
-		}
+	if s.spec.isConst {
+		s.result = s.spec.constant
+		return nil
 	}
 
-	if !hasDoc {
+	val, evalErr := s.spec.expression.Evaluate(doc)
+	if evalErr != nil {
+		s.result = types.Null
+	} else {
+		s.result = val
+	}
+
+	return nil
+}
+
+func (s *lastState) Result() (any, error) {
+	if !s.seen {
 		return types.Null, nil
 	}
 
-	return result, nil
+	return s.result, nil
 }
 
 var (
-	_ Accumulator = (*firstAccumulator)(nil)
-	_ Accumulator = (*lastAccumulator)(nil)
+	_ Accumulator  = (*firstAccumulator)(nil)
+	_ Accumulator  = (*lastAccumulator)(nil)
+	_ Accumulation = (*firstState)(nil)
+	_ Accumulation = (*lastState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/mergeobjects.go
+++ b/internal/handler/common/aggregations/operators/accumulators/mergeobjects.go
@@ -15,13 +15,11 @@
 package accumulators
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations/operators"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
 	"github.com/dolthub/dumbodb/internal/util/must"
 )
 
@@ -74,57 +72,58 @@ func newMergeObjectsAccumulator(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (m *mergeObjectsAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
-
-	result, err := types.NewDocument()
-	if err != nil {
-		return nil, err
-	}
-
-	for {
-		_, doc, err := iter.Next()
-
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		var val any
-
-		switch {
-		case m.isRoot:
-			val = doc
-		case m.operator != nil:
-			var opErr error
-			val, opErr = m.operator.Process(doc)
-			if opErr != nil {
-				continue
-			}
-		case m.expression != nil:
-			var exprErr error
-			val, exprErr = m.expression.Evaluate(doc)
-			if exprErr != nil {
-				continue
-			}
-		default:
-			continue
-		}
-
-		src, ok := val.(*types.Document)
-		if !ok {
-			continue
-		}
-
-		for _, k := range src.Keys() {
-			result.Set(k, must.NotFail(src.Get(k)))
-		}
-	}
-
-	return result, nil
+func (m *mergeObjectsAccumulator) New() Accumulation {
+	return &mergeObjectsState{spec: m, result: must.NotFail(types.NewDocument())}
 }
 
-var _ Accumulator = (*mergeObjectsAccumulator)(nil)
+type mergeObjectsState struct {
+	spec   *mergeObjectsAccumulator
+	result *types.Document
+}
+
+func (s *mergeObjectsState) Accumulate(doc *types.Document) error {
+	m := s.spec
+
+	var val any
+
+	switch {
+	case m.isRoot:
+		val = doc
+	case m.operator != nil:
+		v, opErr := m.operator.Process(doc)
+		if opErr != nil {
+			return nil
+		}
+
+		val = v
+	case m.expression != nil:
+		v, exprErr := m.expression.Evaluate(doc)
+		if exprErr != nil {
+			return nil
+		}
+
+		val = v
+	default:
+		return nil
+	}
+
+	src, ok := val.(*types.Document)
+	if !ok {
+		return nil
+	}
+
+	for _, k := range src.Keys() {
+		s.result.Set(k, must.NotFail(src.Get(k)))
+	}
+
+	return nil
+}
+
+func (s *mergeObjectsState) Result() (any, error) {
+	return s.result, nil
+}
+
+var (
+	_ Accumulator  = (*mergeObjectsAccumulator)(nil)
+	_ Accumulation = (*mergeObjectsState)(nil)
+)

--- a/internal/handler/common/aggregations/operators/accumulators/min_max.go
+++ b/internal/handler/common/aggregations/operators/accumulators/min_max.go
@@ -15,13 +15,9 @@
 package accumulators
 
 import (
-	"errors"
-
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
-	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
 type minAccumulator struct {
@@ -54,55 +50,61 @@ func newMin(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (m *minAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (m *minAccumulator) New() Accumulation {
+	return &extremeState{expression: m.expression, number: m.number, want: types.Less}
+}
 
-	var result any
+func (m *maxAccumulator) New() Accumulation {
+	return &extremeState{expression: m.expression, number: m.number, want: types.Greater}
+}
 
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
+// extremeState folds the running $min or $max. want is the comparison result
+// (types.Less for $min, types.Greater for $max) that replaces the running value.
+type extremeState struct {
+	expression *aggregations.Expression
+	number     any
+	want       types.CompareResult
+	result     any
+}
+
+func (s *extremeState) Accumulate(doc *types.Document) error {
+	var val any
+
+	if s.expression != nil {
+		v, evalErr := s.expression.Evaluate(doc)
+		if evalErr != nil {
+			// missing field: skip (treat as absent)
+			return nil
 		}
 
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		var val any
-
-		if m.expression != nil {
-			v, evalErr := m.expression.Evaluate(doc)
-			if evalErr != nil {
-				// missing field: skip (treat as absent)
-				continue
-			}
-
-			val = v
-		} else {
-			val = m.number
-		}
-
-		// Skip null values ($min ignores nulls)
-		if _, isNull := val.(types.NullType); isNull {
-			continue
-		}
-
-		if result == nil {
-			result = val
-			continue
-		}
-
-		if types.CompareOrder(val, result, types.Ascending) == types.Less {
-			result = val
-		}
+		val = v
+	} else {
+		val = s.number
 	}
 
-	if result == nil {
+	// Skip null values ($min/$max ignore nulls)
+	if _, isNull := val.(types.NullType); isNull {
+		return nil
+	}
+
+	if s.result == nil {
+		s.result = val
+		return nil
+	}
+
+	if types.CompareOrder(val, s.result, types.Ascending) == s.want {
+		s.result = val
+	}
+
+	return nil
+}
+
+func (s *extremeState) Result() (any, error) {
+	if s.result == nil {
 		return types.Null, nil
 	}
 
-	return result, nil
+	return s.result, nil
 }
 
 type maxAccumulator struct {
@@ -134,58 +136,8 @@ func newMax(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (m *maxAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
-
-	var result any
-
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
-
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		var val any
-
-		if m.expression != nil {
-			v, evalErr := m.expression.Evaluate(doc)
-			if evalErr != nil {
-				// missing field: skip (treat as absent)
-				continue
-			}
-
-			val = v
-		} else {
-			val = m.number
-		}
-
-		// Skip null values ($max ignores nulls)
-		if _, isNull := val.(types.NullType); isNull {
-			continue
-		}
-
-		if result == nil {
-			result = val
-			continue
-		}
-
-		if types.CompareOrder(val, result, types.Ascending) == types.Greater {
-			result = val
-		}
-	}
-
-	if result == nil {
-		return types.Null, nil
-	}
-
-	return result, nil
-}
-
 var (
-	_ Accumulator = (*minAccumulator)(nil)
-	_ Accumulator = (*maxAccumulator)(nil)
+	_ Accumulator  = (*minAccumulator)(nil)
+	_ Accumulator  = (*maxAccumulator)(nil)
+	_ Accumulation = (*extremeState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/push.go
+++ b/internal/handler/common/aggregations/operators/accumulators/push.go
@@ -15,15 +15,12 @@
 package accumulators
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations/operators"
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
-	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 	"github.com/dolthub/dumbodb/internal/util/must"
 )
 
@@ -64,42 +61,44 @@ func newPush(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (p *pushAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (p *pushAccumulator) New() Accumulation {
+	// $push must retain every projected value, so its result array grows with
+	// the group size. It retains values, never documents.
+	return &pushState{spec: p, result: types.MakeArray(0)}
+}
 
-	result := types.MakeArray(0)
+type pushState struct {
+	spec   *pushAccumulator
+	result *types.Array
+}
 
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
+func (s *pushState) Accumulate(doc *types.Document) error {
+	p := s.spec
 
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		if p.docExpr != nil {
-			result.Append(evalDocTemplateExpr(p.docExpr, doc))
-			continue
-		}
-
-		if p.isConst {
-			result.Append(p.constant)
-			continue
-		}
-
-		val, evalErr := p.expression.Evaluate(doc)
-		if evalErr != nil {
-			// missing field: push null
-			result.Append(types.Null)
-			continue
-		}
-
-		result.Append(val)
+	if p.docExpr != nil {
+		s.result.Append(evalDocTemplateExpr(p.docExpr, doc))
+		return nil
 	}
 
-	return result, nil
+	if p.isConst {
+		s.result.Append(p.constant)
+		return nil
+	}
+
+	val, evalErr := p.expression.Evaluate(doc)
+	if evalErr != nil {
+		// missing field: push null
+		s.result.Append(types.Null)
+		return nil
+	}
+
+	s.result.Append(val)
+
+	return nil
+}
+
+func (s *pushState) Result() (any, error) {
+	return s.result, nil
 }
 
 // evalDocTemplateExpr evaluates a document template expression against an input document.
@@ -161,5 +160,6 @@ func evalDocTemplateExpr(tmpl, doc *types.Document) *types.Document {
 }
 
 var (
-	_ Accumulator = (*pushAccumulator)(nil)
+	_ Accumulator  = (*pushAccumulator)(nil)
+	_ Accumulation = (*pushState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/stddev.go
+++ b/internal/handler/common/aggregations/operators/accumulators/stddev.go
@@ -15,14 +15,11 @@
 package accumulators
 
 import (
-	"errors"
 	"math"
 
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations"
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
-	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
 type stdDevPopAccumulator struct {
@@ -56,19 +53,8 @@ func newStdDevPop(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (s *stdDevPopAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
-
-	nums, err := collectNumericValues(iter, s.expression, s.number)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(nums) == 0 {
-		return types.Null, nil
-	}
-
-	return stdDevPop(nums), nil
+func (s *stdDevPopAccumulator) New() Accumulation {
+	return &stdDevState{expression: s.expression, number: s.number, sample: false}
 }
 
 type stdDevSampAccumulator struct {
@@ -102,60 +88,61 @@ func newStdDevSamp(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (s *stdDevSampAccumulator) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (s *stdDevSampAccumulator) New() Accumulation {
+	return &stdDevState{expression: s.expression, number: s.number, sample: true}
+}
 
-	nums, err := collectNumericValues(iter, s.expression, s.number)
-	if err != nil {
-		return nil, err
+// stdDevState collects numeric values for a group and computes the standard
+// deviation at the end. The two-pass mean/variance computation is retained for
+// numerical parity, so this accumulator holds the group's numeric values (not
+// its documents). A numerically-stable online variant is a future optimization.
+type stdDevState struct {
+	expression *aggregations.Expression
+	number     any
+	sample     bool
+	nums       []float64
+}
+
+func (s *stdDevState) Accumulate(doc *types.Document) error {
+	var val any
+
+	if s.expression != nil {
+		v, evalErr := s.expression.Evaluate(doc)
+		if evalErr != nil {
+			return nil
+		}
+
+		val = v
+	} else {
+		val = s.number
 	}
 
-	if len(nums) < 2 {
+	switch v := val.(type) {
+	case float64:
+		s.nums = append(s.nums, v)
+	case int32:
+		s.nums = append(s.nums, float64(v))
+	case int64:
+		s.nums = append(s.nums, float64(v))
+	}
+
+	return nil
+}
+
+func (s *stdDevState) Result() (any, error) {
+	if s.sample {
+		if len(s.nums) < 2 {
+			return types.Null, nil
+		}
+
+		return stdDevSamp(s.nums), nil
+	}
+
+	if len(s.nums) == 0 {
 		return types.Null, nil
 	}
 
-	return stdDevSamp(nums), nil
-}
-
-// collectNumericValues iterates documents, evaluating expression or using the constant,
-// and returns only numeric (float64) values.
-func collectNumericValues(iter types.DocumentsIterator, expr *aggregations.Expression, constant any) ([]float64, error) {
-	var nums []float64
-
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
-
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		var val any
-
-		if expr != nil {
-			v, evalErr := expr.Evaluate(doc)
-			if evalErr != nil {
-				continue
-			}
-
-			val = v
-		} else {
-			val = constant
-		}
-
-		switch v := val.(type) {
-		case float64:
-			nums = append(nums, v)
-		case int32:
-			nums = append(nums, float64(v))
-		case int64:
-			nums = append(nums, float64(v))
-		}
-	}
-
-	return nums, nil
+	return stdDevPop(s.nums), nil
 }
 
 // stdDevPop computes population standard deviation.
@@ -203,6 +190,7 @@ func stdDevSamp(nums []float64) float64 {
 }
 
 var (
-	_ Accumulator = (*stdDevPopAccumulator)(nil)
-	_ Accumulator = (*stdDevSampAccumulator)(nil)
+	_ Accumulator  = (*stdDevPopAccumulator)(nil)
+	_ Accumulator  = (*stdDevSampAccumulator)(nil)
+	_ Accumulation = (*stdDevState)(nil)
 )

--- a/internal/handler/common/aggregations/operators/accumulators/sum.go
+++ b/internal/handler/common/aggregations/operators/accumulators/sum.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/dumbodb/internal/handler/common/aggregations/operators"
 	"github.com/dolthub/dumbodb/internal/handler/handlererrors"
 	"github.com/dolthub/dumbodb/internal/types"
-	"github.com/dolthub/dumbodb/internal/util/iterator"
 	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
@@ -80,59 +79,53 @@ func newSum(args ...any) (Accumulator, error) {
 	return accumulator, nil
 }
 
-func (s *sum) Accumulate(iter types.DocumentsIterator) (any, error) {
-	defer iter.Close()
+func (s *sum) New() Accumulation {
+	return &sumState{spec: s, acc: aggregations.NewNumberSum()}
+}
 
-	var numbers []any
+type sumState struct {
+	spec *sum
+	acc  *aggregations.NumberSum
+}
 
-	for {
-		_, doc, err := iter.Next()
+func (st *sumState) Accumulate(doc *types.Document) error {
+	s := st.spec
 
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
-
+	switch {
+	case s.operator != nil:
+		v, err := s.operator.Process(doc)
 		if err != nil {
-			return nil, lazyerrors.Error(err)
+			return err
 		}
 
-		switch {
-		case s.operator != nil:
-			v, err := s.operator.Process(doc)
-			if err != nil {
-				return nil, err
-			}
+		st.acc.Add(v)
 
-			numbers = append(numbers, v)
+		return nil
 
-			continue
-
-		case s.expression != nil:
-			value, err := s.expression.Evaluate(doc)
-
-			// sum fields that exist
-			if err == nil {
-				numbers = append(numbers, value)
-			}
-
-			continue
+	case s.expression != nil:
+		// sum fields that exist
+		if value, err := s.expression.Evaluate(doc); err == nil {
+			st.acc.Add(value)
 		}
 
-		switch number := s.number.(type) {
-		case float64, int32, int64:
-			// For number types, the result is equivalent of iterator len*number,
-			// with conversion handled upon overflow of int32 and int64.
-			// For example, { $sum: 1 } is equivalent of { $count: { } }.
-			numbers = append(numbers, number)
-		default:
-			// $sum returns 0 on non-existent and non-numeric field.
-			return int32(0), nil
-		}
+		return nil
 	}
 
-	return aggregations.SumNumbers(numbers...), nil
+	// Constant: { $sum: 1 } folds the same value per document (equivalent to
+	// $count). Non-numeric constants contribute nothing, so Result stays int32(0).
+	switch s.number.(type) {
+	case float64, int32, int64:
+		st.acc.Add(s.number)
+	}
+
+	return nil
+}
+
+func (st *sumState) Result() (any, error) {
+	return st.acc.Result(), nil
 }
 
 var (
-	_ Accumulator = (*sum)(nil)
+	_ Accumulator  = (*sum)(nil)
+	_ Accumulation = (*sumState)(nil)
 )

--- a/internal/handler/common/aggregations/stages/bucket.go
+++ b/internal/handler/common/aggregations/stages/bucket.go
@@ -282,7 +282,7 @@ func appendBucketOutput(doc *types.Document, output []bucketOutput, groupDocs []
 
 	for _, out := range output {
 		iter := iterator.Values(iterator.ForSlice(groupDocs))
-		val, err := out.accumulator.Accumulate(iter)
+		val, err := accumulators.Accumulate(out.accumulator, iter)
 
 		if err != nil {
 			val = types.Null

--- a/internal/handler/common/aggregations/stages/group.go
+++ b/internal/handler/common/aggregations/stages/group.go
@@ -128,43 +128,98 @@ func newGroup(stage *types.Document) (aggregations.Stage, error) {
 }
 
 func (g *group) Process(ctx context.Context, iter types.DocumentsIterator, closer *iterator.MultiCloser) (types.DocumentsIterator, error) { //nolint:lll // for readability
-	groupedDocuments, err := g.groupDocuments(iter)
-	if err != nil {
-		return nil, err
+	defer iter.Close()
+
+	// Fold each document into its group's accumulators as it streams; documents
+	// are never retained, so memory scales with the number of groups (and any
+	// inherently-retaining accumulators like $push), not the input size.
+	gm := newGroupMap(g.groupBy)
+
+	for {
+		_, doc, err := iter.Next()
+		if errors.Is(err, iterator.ErrIteratorDone) {
+			break
+		}
+
+		if err != nil {
+			return nil, lazyerrors.Error(err)
+		}
+
+		groupKey, err := g.evalGroupKey(doc)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := gm.accumulate(groupKey, doc); err != nil {
+			// existing accumulators rarely return error
+			return nil, processGroupStageError(err)
+		}
 	}
 
 	var res []*types.Document
 
-	for _, groupedDocument := range groupedDocuments {
-		doc := must.NotFail(types.NewDocument("_id", groupedDocument.groupID))
+	for i := range gm.docs {
+		grp := &gm.docs[i]
 
-		for _, accumulation := range g.groupBy {
-			groupIter := iterator.Values(iterator.ForSlice(groupedDocument.documents))
-			out, err := accumulation.accumulator.Accumulate(groupIter)
+		doc := must.NotFail(types.NewDocument("_id", grp.groupID))
+
+		for j, acc := range grp.accs {
+			out, err := acc.Result()
 			if err != nil {
-				// existing accumulators do not return error
 				return nil, processGroupStageError(err)
 			}
 
-			if doc.Has(accumulation.outputField) {
+			field := g.groupBy[j].outputField
+
+			if doc.Has(field) {
 				// document has duplicate key
 				return nil, handlererrors.NewCommandErrorMsgWithArgument(
 					handlererrors.ErrStageIndexedStringVectorDuplicate,
-					fmt.Sprintf("duplicate field: %s", accumulation.outputField),
+					fmt.Sprintf("duplicate field: %s", field),
 					"$group (stage)",
 				)
 			}
 
-			doc.Set(accumulation.outputField, out)
+			doc.Set(field, out)
 		}
 
 		res = append(res, doc)
 	}
 
-	iter = iterator.Values(iterator.ForSlice(res))
-	closer.Add(iter)
+	resIter := iterator.Values(iterator.ForSlice(res))
+	closer.Add(resIter)
 
-	return iter, nil
+	return resIter, nil
+}
+
+// evalGroupKey computes the _id group key for one document. It mirrors the type
+// handling of the group expression: documents are evaluated recursively,
+// "$field" strings resolve via the precompiled expression (missing -> null),
+// and other literal BSON types are used as-is.
+func (g *group) evalGroupKey(doc *types.Document) (any, error) {
+	switch groupKey := g.groupExpression.(type) {
+	case *types.Document:
+		return evaluateDocument(groupKey, doc, false)
+	case *types.Array, float64, types.Binary, types.ObjectID, bool, time.Time, types.NullType,
+		types.Regex, int32, types.Timestamp, int64:
+		return groupKey, nil
+	case string:
+		// g.groupExprCompiled is set iff groupKey is a valid "$path"
+		// expression; a plain literal leaves it nil and is used as-is.
+		if g.groupExprCompiled == nil {
+			return groupKey, nil
+		}
+
+		val, err := g.groupExprCompiled.Evaluate(doc)
+		if err != nil {
+			// $group treats non-existent fields as nulls
+			return types.Null, nil
+		}
+
+		return val, nil
+	default:
+		panic(fmt.Sprintf("unexpected type %[1]T (%#[1]v)", groupKey))
+	}
 }
 
 // validateGroupKey returns error on invalid group key.
@@ -229,58 +284,6 @@ func validateGroupKey(groupKey any) error {
 	}
 
 	return nil
-}
-
-// groupDocuments groups documents into groups using group key. If group key contains expressions
-// or operators, they are evaluated before using it as the group key of documents.
-func (g *group) groupDocuments(iter types.DocumentsIterator) ([]groupedDocuments, error) {
-	defer iter.Close()
-
-	var m groupMap
-
-	for {
-		_, doc, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			break
-		}
-
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
-
-		switch groupKey := g.groupExpression.(type) {
-		case *types.Document:
-			val, err := evaluateDocument(groupKey, doc, false)
-			if err != nil {
-				// operator and expression errors are validated in newGroup
-				return nil, lazyerrors.Error(err)
-			}
-
-			m.addOrAppend(val, doc)
-		case *types.Array, float64, types.Binary, types.ObjectID, bool, time.Time, types.NullType,
-			types.Regex, int32, types.Timestamp, int64:
-			m.addOrAppend(groupKey, doc)
-		case string:
-			// g.groupExprCompiled is set iff groupKey is a valid "$path"
-			// expression; a plain literal leaves it nil and is added as-is.
-			if g.groupExprCompiled == nil {
-				m.addOrAppend(groupKey, doc)
-				continue
-			}
-
-			val, err := g.groupExprCompiled.Evaluate(doc)
-			if err != nil {
-				// $group treats non-existent fields as nulls
-				val = types.Null
-			}
-
-			m.addOrAppend(val, doc)
-		default:
-			panic(fmt.Sprintf("unexpected type %[1]T (%#[1]v)", groupKey))
-		}
-	}
-
-	return m.docs, nil
 }
 
 // evaluateDocument recursively evaluates document's field expressions and operators.
@@ -358,11 +361,13 @@ func evaluateDocument(expr, doc *types.Document, nestedField bool) (any, error) 
 }
 
 type groupedDocuments struct {
-	groupID   any
-	documents []*types.Document
+	groupID any
+	// accs holds one live accumulation per groupBy spec, folded as documents
+	// stream in. Documents themselves are not retained.
+	accs []accumulators.Accumulation
 }
 
-// groupMap holds groups of documents.
+// groupMap holds the running accumulators for each group.
 //
 // Group keys can be any BSON type (including arrays and binaries) and
 // numeric types are grouped numerically regardless of int/int64/float  -- so
@@ -370,25 +375,43 @@ type groupedDocuments struct {
 // For hashable, comparably-typed keys (strings, bools, int32/int64, ObjectID)
 // a fast path map indexes into docs, cutting O(n*k) group lookups to O(n).
 type groupMap struct {
-	docs []groupedDocuments
-	// fast indexes groupedDocuments by key for keys that cannot collide
-	// with numerically-equal keys of another Go type. Numeric keys are
+	specs []groupBy
+	docs  []groupedDocuments
+	// fast indexes docs by key for keys that cannot collide with
+	// numerically-equal keys of another Go type. Numeric keys are
 	// intentionally excluded because CompareForAggregation treats
 	// int32(1)/int64(1)/float64(1.0) as equal.
 	fast map[any]int
 }
 
-// addOrAppend adds a groupID documents pair if the groupID does not exist,
-// if the groupID exists it appends the documents to the slice.
-func (m *groupMap) addOrAppend(groupKey any, docs ...*types.Document) {
+func newGroupMap(specs []groupBy) *groupMap {
+	return &groupMap{specs: specs}
+}
+
+// accumulate routes doc into its group (creating the group and its fresh
+// accumulators on first sight) and folds doc through each accumulator.
+func (m *groupMap) accumulate(groupKey any, doc *types.Document) error {
+	idx := m.index(groupKey)
+
+	for _, acc := range m.docs[idx].accs {
+		if err := acc.Accumulate(doc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// index returns the slot for groupKey, creating a new group with fresh
+// accumulators when none exists yet.
+func (m *groupMap) index(groupKey any) int {
 	if hashable, key := hashableGroupKey(groupKey); hashable {
 		if m.fast == nil {
 			m.fast = make(map[any]int)
 		}
 
 		if i, ok := m.fast[key]; ok {
-			m.docs[i].documents = append(m.docs[i].documents, docs...)
-			return
+			return i
 		}
 
 		// No entry yet  -- but a numeric-equal entry might already exist in
@@ -396,18 +419,15 @@ func (m *groupMap) addOrAppend(groupKey any, docs ...*types.Document) {
 		// Scan once to stay consistent with CompareForAggregation semantics.
 		for i, g := range m.docs {
 			if types.CompareForAggregation(groupKey, g.groupID) == types.Equal {
-				m.docs[i].documents = append(m.docs[i].documents, docs...)
 				m.fast[key] = i
-				return
+				return i
 			}
 		}
 
-		m.fast[key] = len(m.docs)
-		m.docs = append(m.docs, groupedDocuments{
-			groupID:   groupKey,
-			documents: docs,
-		})
-		return
+		i := m.newGroup(groupKey)
+		m.fast[key] = i
+
+		return i
 	}
 
 	for i, g := range m.docs {
@@ -416,15 +436,24 @@ func (m *groupMap) addOrAppend(groupKey any, docs ...*types.Document) {
 		// Compare is used to check if groupID exists in groupMap, because
 		// numbers are grouped for the same value regardless of their number type.
 		if types.CompareForAggregation(groupKey, g.groupID) == types.Equal {
-			m.docs[i].documents = append(m.docs[i].documents, docs...)
-			return
+			return i
 		}
 	}
 
-	m.docs = append(m.docs, groupedDocuments{
-		groupID:   groupKey,
-		documents: docs,
-	})
+	return m.newGroup(groupKey)
+}
+
+// newGroup appends a group for groupKey with a fresh accumulation per spec and
+// returns its index.
+func (m *groupMap) newGroup(groupKey any) int {
+	accs := make([]accumulators.Accumulation, len(m.specs))
+	for i := range m.specs {
+		accs[i] = m.specs[i].accumulator.New()
+	}
+
+	m.docs = append(m.docs, groupedDocuments{groupID: groupKey, accs: accs})
+
+	return len(m.docs) - 1
 }
 
 // hashableGroupKey returns true and a map-friendly key when groupKey is a

--- a/internal/handler/common/aggregations/stages/sort.go
+++ b/internal/handler/common/aggregations/stages/sort.go
@@ -26,12 +26,20 @@ import (
 	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
 )
 
-// sort represents $sort stage.
+// sort represents $sort stage. limit is the top-K bound when a $limit (or
+// $skip + $limit) immediately follows; 0 means an unbounded full sort.
 type sort struct {
 	fields *types.Document
+	limit  int64
 }
 
 func newSort(stage *types.Document) (aggregations.Stage, error) {
+	return NewSortStage(stage, 0)
+}
+
+// NewSortStage builds a $sort stage that keeps only the first limit documents
+// (in sort order) when limit > 0, bounding memory for a following $limit.
+func NewSortStage(stage *types.Document, limit int64) (aggregations.Stage, error) {
 	fields, err := common.GetRequiredParam[*types.Document](stage, "$sort")
 	if err != nil {
 		return nil, handlererrors.NewCommandErrorMsgWithArgument(
@@ -49,9 +57,9 @@ func newSort(stage *types.Document) (aggregations.Stage, error) {
 		)
 	}
 
-
 	return &sort{
 		fields: fields,
+		limit:  limit,
 	}, nil
 }
 
@@ -59,7 +67,7 @@ func newSort(stage *types.Document) (aggregations.Stage, error) {
 //
 // If sort path is invalid, it returns a possibly wrapped types.PathError.
 func (s *sort) Process(ctx context.Context, iter types.DocumentsIterator, closer *iterator.MultiCloser) (types.DocumentsIterator, error) { //nolint:lll // for readability
-	iter, err := common.SortIterator(iter, closer, s.fields)
+	iter, err := common.TopKIterator(iter, closer, s.fields, s.limit)
 	if err != nil {
 		var pathErr *types.PathError
 		if errors.As(err, &pathErr) && pathErr.Code() == types.ErrPathElementEmpty {

--- a/internal/handler/common/topk_iterator.go
+++ b/internal/handler/common/topk_iterator.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+
+	"github.com/dolthub/dumbodb/internal/types"
+	"github.com/dolthub/dumbodb/internal/util/iterator"
+	"github.com/dolthub/dumbodb/internal/util/lazyerrors"
+)
+
+// maxTopKBuffer bounds the working set TopKIterator will hold. Above it the
+// bounded buffer no longer saves memory, so a full sort is used instead.
+const maxTopKBuffer = 1 << 20
+
+// TopKIterator returns the first k documents of a stable sort by sortDoc, in
+// sorted order, while holding at most ~2k documents in memory rather than the
+// whole input. It is equivalent to SortIterator followed by a limit of k,
+// including ties: among equal sort keys earlier input documents win, because
+// retained documents are always re-sorted ahead of later arrivals. k <= 0 (or a
+// k too large to bound usefully) falls back to a full sort.
+func TopKIterator(iter types.DocumentsIterator, closer *iterator.MultiCloser, sortDoc *types.Document, k int64) (types.DocumentsIterator, error) { //nolint:lll // for readability
+	if k <= 0 || k > maxTopKBuffer || sortDoc.Len() == 0 {
+		return SortIterator(iter, closer, sortDoc)
+	}
+
+	defer iter.Close()
+
+	trimAt := 2 * k
+
+	initCap := trimAt
+	if initCap > 4096 {
+		initCap = 4096
+	}
+
+	buf := make([]*types.Document, 0, initCap)
+
+	for {
+		_, doc, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, iterator.ErrIteratorDone) {
+				break
+			}
+
+			return nil, lazyerrors.Error(err)
+		}
+
+		buf = append(buf, doc)
+
+		if int64(len(buf)) >= trimAt {
+			if err := SortDocuments(buf, sortDoc); err != nil {
+				return nil, lazyerrors.Error(err)
+			}
+
+			buf = trimTopK(buf, k)
+		}
+	}
+
+	if err := SortDocuments(buf, sortDoc); err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	if int64(len(buf)) > k {
+		buf = trimTopK(buf, k)
+	}
+
+	res := iterator.Values(iterator.ForSlice(buf))
+	closer.Add(res)
+
+	return res, nil
+}
+
+// trimTopK keeps the first k documents and releases references to the rest so
+// they can be collected, reusing the backing array.
+func trimTopK(buf []*types.Document, k int64) []*types.Document {
+	for i := k; i < int64(len(buf)); i++ {
+		buf[i] = nil
+	}
+
+	return buf[:k]
+}

--- a/internal/handler/common/topk_iterator_test.go
+++ b/internal/handler/common/topk_iterator_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/dolthub/dumbodb/internal/types"
+	"github.com/dolthub/dumbodb/internal/util/iterator"
+	"github.com/dolthub/dumbodb/internal/util/must"
+)
+
+// topKReferenceIDs returns the "id" sequence of a full stable sort by sortDoc
+// truncated to k, the behavior TopKIterator must reproduce.
+func topKReferenceIDs(t *testing.T, docs []*types.Document, sortDoc *types.Document, k int64) []int32 {
+	t.Helper()
+
+	cp := make([]*types.Document, len(docs))
+	copy(cp, docs)
+
+	if err := SortDocuments(cp, sortDoc); err != nil {
+		t.Fatalf("SortDocuments: %v", err)
+	}
+
+	if int64(len(cp)) > k {
+		cp = cp[:k]
+	}
+
+	return docIDs(t, cp)
+}
+
+func docIDs(t *testing.T, docs []*types.Document) []int32 {
+	t.Helper()
+
+	ids := make([]int32, len(docs))
+	for i, d := range docs {
+		ids[i] = must.NotFail(d.Get("id")).(int32)
+	}
+
+	return ids
+}
+
+func TestTopKIterator(t *testing.T) {
+	sortDoc := must.NotFail(types.NewDocument("v", int32(1)))
+
+	// values include heavy ties so the tie-stability path is exercised.
+	values := []int32{5, 3, 3, 1, 9, 3, 1, 7, 2, 8, 3, 1, 6, 4, 0, 3, 1, 5, 2, 9}
+
+	build := func() []*types.Document {
+		docs := make([]*types.Document, len(values))
+		for i, v := range values {
+			docs[i] = must.NotFail(types.NewDocument("v", v, "id", int32(i)))
+		}
+
+		return docs
+	}
+
+	for _, k := range []int64{1, 3, 5, 10, 20, 50} {
+		docs := build()
+
+		closer := iterator.NewMultiCloser()
+		iter, err := TopKIterator(iterator.Values(iterator.ForSlice(docs)), closer, sortDoc, k)
+		if err != nil {
+			t.Fatalf("k=%d: TopKIterator: %v", k, err)
+		}
+
+		got, err := iterator.ConsumeValues(iter)
+		closer.Close()
+		if err != nil {
+			t.Fatalf("k=%d: consume: %v", k, err)
+		}
+
+		want := topKReferenceIDs(t, build(), sortDoc, k)
+		gotIDs := docIDs(t, got)
+
+		if len(gotIDs) != len(want) {
+			t.Fatalf("k=%d: len got=%d want=%d", k, len(gotIDs), len(want))
+		}
+
+		for i := range want {
+			if gotIDs[i] != want[i] {
+				t.Fatalf("k=%d: position %d: got id=%d want id=%d\n got=%v\nwant=%v",
+					k, i, gotIDs[i], want[i], gotIDs, want)
+			}
+		}
+	}
+}

--- a/internal/handler/msg_aggregate.go
+++ b/internal/handler/msg_aggregate.go
@@ -269,6 +269,11 @@ func (h *Handler) MsgAggregate(connCtx context.Context, msg *wire.OpMsg) (*wire.
 			// $indexStats requires collection access to retrieve index metadata.
 			s, err = stages.NewIndexStatsStage(d, connCtx, c, h.TCPHost)
 
+		case "$sort":
+			// Coalesce a following $limit (or $skip + $limit) into a top-K bound
+			// so $sort holds only the needed documents instead of the whole input.
+			s, err = stages.NewSortStage(d, sortLimitBound(aggregationStages, i))
+
 		default:
 			s, err = stages.NewStage(d)
 		}
@@ -689,6 +694,60 @@ type stagesDocumentsParams struct {
 }
 
 // processStagesDocuments retrieves the documents from the database and then processes them through the stages.
+// sortLimitBound returns the top-K bound a $sort at index i may use when a
+// $limit (optionally preceded by a $skip) immediately follows it, else 0. This
+// mirrors MongoDB's sort+limit and sort+skip+limit coalescence.
+func sortLimitBound(aggregationStages []any, i int) int64 {
+	next := stageDocAt(aggregationStages, i+1)
+	if next == nil {
+		return 0
+	}
+
+	switch next.Command() {
+	case "$limit":
+		if l, ok := stageInt64(next, "$limit", common.GetLimitStageParam); ok {
+			return l
+		}
+	case "$skip":
+		after := stageDocAt(aggregationStages, i+2)
+		if after == nil || after.Command() != "$limit" {
+			return 0
+		}
+
+		s, sok := stageInt64(next, "$skip", common.GetSkipStageParam)
+		l, lok := stageInt64(after, "$limit", common.GetLimitStageParam)
+		if sok && lok {
+			return s + l
+		}
+	}
+
+	return 0
+}
+
+func stageDocAt(aggregationStages []any, i int) *types.Document {
+	if i < 0 || i >= len(aggregationStages) {
+		return nil
+	}
+
+	d, _ := aggregationStages[i].(*types.Document)
+
+	return d
+}
+
+func stageInt64(d *types.Document, key string, parse func(any) (int64, error)) (int64, bool) {
+	v, err := d.Get(key)
+	if err != nil {
+		return 0, false
+	}
+
+	n, err := parse(v)
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
+}
+
 func processStagesDocuments(ctx context.Context, closer *iterator.MultiCloser, p *stagesDocumentsParams) (types.DocumentsIterator, error) { //nolint:lll // for readability
 	queryRes, err := p.c.Query(ctx, p.qp)
 	if err != nil {


### PR DESCRIPTION
Turns out that $group aggregations were loading all documents when that wasn't required.