### PR TITLE
merge empty base

### DIFF
--- a/internal/backends/dolt/merge_conflict.go
+++ b/internal/backends/dolt/merge_conflict.go
@@ -1233,7 +1233,15 @@ func mergeAddressMapsWithConflicts(ctx context.Context, state *dbState, intoAM, 
 		if err != nil {
 			return prolly.AddressMap{}, nil, fmt.Errorf("opening from collection %q: %w", name, err)
 		}
-		baseMap, err := openCollection(ctx, state.cs, state.ns, baseH)
+		// When the collection was added independently on both branches it is
+		// absent from the merge base (baseH is the zero hash); the 3-way merge
+		// treats the missing base as an empty collection map.
+		var baseMap prolly.Map
+		if baseH.IsEmpty() {
+			baseMap, err = newEmptyMap(ctx, state.ns)
+		} else {
+			baseMap, err = openCollection(ctx, state.cs, state.ns, baseH)
+		}
 		if err != nil {
 			return prolly.AddressMap{}, nil, fmt.Errorf("opening base collection %q: %w", name, err)
 		}
@@ -1248,7 +1256,12 @@ func mergeAddressMapsWithConflicts(ctx context.Context, state *dbState, intoAM, 
 		if idxErr != nil {
 			return prolly.AddressMap{}, nil, fmt.Errorf("reading from index AM for %q: %w", name, idxErr)
 		}
-		baseIdxAM, idxErr := indexAMForDTBL(ctx, state.cs, state.ns, baseH)
+		var baseIdxAM prolly.AddressMap
+		if baseH.IsEmpty() {
+			baseIdxAM, idxErr = prolly.NewEmptyAddressMap(state.ns)
+		} else {
+			baseIdxAM, idxErr = indexAMForDTBL(ctx, state.cs, state.ns, baseH)
+		}
 		if idxErr != nil {
 			return prolly.AddressMap{}, nil, fmt.Errorf("reading base index AM for %q: %w", name, idxErr)
 		}

--- a/internal/backends/dolt/merge_conflict.go
+++ b/internal/backends/dolt/merge_conflict.go
@@ -1233,9 +1233,6 @@ func mergeAddressMapsWithConflicts(ctx context.Context, state *dbState, intoAM, 
 		if err != nil {
 			return prolly.AddressMap{}, nil, fmt.Errorf("opening from collection %q: %w", name, err)
 		}
-		// When the collection was added independently on both branches it is
-		// absent from the merge base (baseH is the zero hash); the 3-way merge
-		// treats the missing base as an empty collection map.
 		var baseMap prolly.Map
 		if baseH.IsEmpty() {
 			baseMap, err = newEmptyMap(ctx, state.ns)

--- a/tests/merge_added_collection_test.go
+++ b/tests/merge_added_collection_test.go
@@ -40,39 +40,30 @@ func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	ctx := context.Background()
 	dbName := fmt.Sprintf("mergeadd_%d", rand.Int64N(1_000_000))
 
-	// Base commit A: only "item" exists here. This is the merge base.
-	base := env.Client.Database(dbName)
-	require.NoError(t, base.Drop(ctx))
-	_, err := base.Collection("item").InsertOne(ctx,
-		bson.D{{Key: "_id", Value: int32(1)}, {Key: "v", Value: "base"}})
-	require.NoError(t, err)
-	dumboDBCommit(t, env, dbName, "A: base with item", "alice <a@x.io>")
-
-	// Branch featureA from main at A.
-	mainDB := env.Client.Database(dbName + "@main")
-	featDB := env.Client.Database(dbName + "@featureA")
-	require.NoError(t, mainDB.RunCommand(ctx, bson.D{
-		{Key: "doltBranch", Value: int32(1)}, {Key: "branch", Value: "featureA"},
-	}).Err())
-
-	// main independently creates a NEW collection "items" (absent in base A).
-	_, err = mainDB.Collection("items").InsertOne(ctx,
+	// main creates a new collection "items".
+	mainDB := env.Client.Database(dbName)
+	require.NoError(t, mainDB.Drop(ctx))
+	_, err := mainDB.Collection("items").InsertOne(ctx,
 		bson.D{{Key: "_id", Value: int32(10)}, {Key: "side", Value: "main"}})
 	require.NoError(t, err)
-	dumboDBCommit(t, env, dbName+"@main", "main: add items/10", "alice <a@x.io>")
+	dumboDBCommit(t, env, dbName, "main: add items/10", "alice <a@x.io>")
 
-	// featureA independently creates the SAME new collection "items" with a
-	// different _id, so the merge itself is conflict-free once the empty base is
-	// handled.
+	// featureA branches from before "items" existed (main~1, the root), then adds
+	// the SAME collection independently. "items" is therefore absent from the
+	// merge base.
+	require.NoError(t, env.Client.Database(dbName+"@main~1").RunCommand(ctx, bson.D{
+		{Key: "doltBranch", Value: int32(1)}, {Key: "branch", Value: "featureA"},
+	}).Err())
+	featDB := env.Client.Database(dbName + "@featureA")
 	_, err = featDB.Collection("items").InsertOne(ctx,
 		bson.D{{Key: "_id", Value: int32(20)}, {Key: "side", Value: "featureA"}})
 	require.NoError(t, err)
 	dumboDBCommit(t, env, dbName+"@featureA", "featureA: add items/20", "bob <b@x.io>")
 
 	// Merge featureA into main. "items" was added on both sides and is absent
-	// from base A, so its base collection hash is empty.
+	// from the merge base, so its base collection hash is empty.
 	var res bson.M
-	err = mainDB.RunCommand(ctx, bson.D{
+	err = env.Client.Database(dbName+"@main").RunCommand(ctx, bson.D{
 		{Key: "doltMerge", Value: int32(1)},
 		{Key: "merge_in", Value: "featureA"},
 		{Key: "message", Value: "merge featureA into main"},
@@ -82,8 +73,9 @@ func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	assert.EqualValues(t, 1, res["ok"])
 
 	// Both independently-added documents survive the merge.
-	require.NoError(t, mainDB.Collection("items").FindOne(ctx,
-		bson.D{{Key: "_id", Value: int32(10)}}).Err(), "main's items/10 must survive")
-	require.NoError(t, mainDB.Collection("items").FindOne(ctx,
-		bson.D{{Key: "_id", Value: int32(20)}}).Err(), "featureA's items/20 must survive")
+	merged := env.Client.Database(dbName + "@main").Collection("items")
+	require.NoError(t, merged.FindOne(ctx, bson.D{{Key: "_id", Value: int32(10)}}).Err(),
+		"main's items/10 must survive")
+	require.NoError(t, merged.FindOne(ctx, bson.D{{Key: "_id", Value: int32(20)}}).Err(),
+		"featureA's items/20 must survive")
 }

--- a/tests/merge_added_collection_test.go
+++ b/tests/merge_added_collection_test.go
@@ -62,3 +62,43 @@ func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	require.NoError(t, merged.FindOne(ctx, bson.D{{Key: "_id", Value: int32(20)}}).Err(),
 		"featureA's items/20 must survive")
 }
+
+func TestMerge_CollectionAddedOnBothBranches_Conflict(t *testing.T) {
+	env := startDumboDB(t)
+	ctx := context.Background()
+	dbName := fmt.Sprintf("mergeaddc_%d", rand.Int64N(1_000_000))
+
+	mainDB := env.Client.Database(dbName)
+	require.NoError(t, mainDB.Drop(ctx))
+	_, err := mainDB.Collection("items").InsertOne(ctx,
+		bson.D{{Key: "_id", Value: int32(10)}, {Key: "v", Value: "main"}})
+	require.NoError(t, err)
+	dumboDBCommit(t, env, dbName, "main: add items/10", "alice <a@x.io>")
+
+	require.NoError(t, env.Client.Database(dbName+"@main~1").RunCommand(ctx, bson.D{
+		{Key: "doltBranch", Value: int32(1)}, {Key: "branch", Value: "featureA"},
+	}).Err())
+	featDB := env.Client.Database(dbName + "@featureA")
+	_, err = featDB.Collection("items").InsertOne(ctx,
+		bson.D{{Key: "_id", Value: int32(10)}, {Key: "v", Value: "featureA"}})
+	require.NoError(t, err)
+	dumboDBCommit(t, env, dbName+"@featureA", "featureA: add items/10", "bob <b@x.io>")
+
+	branch := env.Client.Database(dbName + "@main")
+	raw := runCommandRaw(t, branch, bson.D{
+		{Key: "doltMerge", Value: int32(1)},
+		{Key: "merge_in", Value: "featureA"},
+		{Key: "message", Value: "merge featureA into main"},
+		{Key: "author", Value: "alice <a@x.io>"},
+	})
+	require.EqualValues(t, 0, raw["ok"], "same _id added on both branches must conflict")
+
+	conflicts := getConflictsByCollection(t, branch)
+	require.Len(t, conflicts["items"], 1, "one conflict on items/10")
+
+	resolveAllConflicts(t, branch, "ours")
+	mergeContinue(t, branch)
+
+	col := branch.Collection("items")
+	assert.Equal(t, "main", getDocField(t, col, 10, "v"), "ours resolution keeps main's value")
+}

--- a/tests/merge_added_collection_test.go
+++ b/tests/merge_added_collection_test.go
@@ -25,22 +25,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// TestMerge_CollectionAddedOnBothBranches reproduces workspace-d1b: merging a
-// collection that was created independently on both branches (so it is absent
-// from the merge base) must not crash. The base collection hash for such a
-// collection is the zero hash, and the 3-way collection merge must treat the
-// missing base as an empty map rather than trying to open it.
-//
-// Before the fix this fails with:
-//
-//	DumboDBMerge: opening base collection "items": unexpected file ID "" for
-//	collection (want DTBL or TUPM)
 func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	env := startDumboDB(t)
 	ctx := context.Background()
 	dbName := fmt.Sprintf("mergeadd_%d", rand.Int64N(1_000_000))
 
-	// main creates a new collection "items".
 	mainDB := env.Client.Database(dbName)
 	require.NoError(t, mainDB.Drop(ctx))
 	_, err := mainDB.Collection("items").InsertOne(ctx,
@@ -48,9 +37,6 @@ func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	require.NoError(t, err)
 	dumboDBCommit(t, env, dbName, "main: add items/10", "alice <a@x.io>")
 
-	// featureA branches from before "items" existed (main~1, the root), then adds
-	// the SAME collection independently. "items" is therefore absent from the
-	// merge base.
 	require.NoError(t, env.Client.Database(dbName+"@main~1").RunCommand(ctx, bson.D{
 		{Key: "doltBranch", Value: int32(1)}, {Key: "branch", Value: "featureA"},
 	}).Err())
@@ -60,8 +46,6 @@ func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	require.NoError(t, err)
 	dumboDBCommit(t, env, dbName+"@featureA", "featureA: add items/20", "bob <b@x.io>")
 
-	// Merge featureA into main. "items" was added on both sides and is absent
-	// from the merge base, so its base collection hash is empty.
 	var res bson.M
 	err = env.Client.Database(dbName+"@main").RunCommand(ctx, bson.D{
 		{Key: "doltMerge", Value: int32(1)},
@@ -72,7 +56,6 @@ func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
 	require.NoError(t, err, "merging a collection added on both branches must not error")
 	assert.EqualValues(t, 1, res["ok"])
 
-	// Both independently-added documents survive the merge.
 	merged := env.Client.Database(dbName + "@main").Collection("items")
 	require.NoError(t, merged.FindOne(ctx, bson.D{{Key: "_id", Value: int32(10)}}).Err(),
 		"main's items/10 must survive")

--- a/tests/merge_added_collection_test.go
+++ b/tests/merge_added_collection_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TestMerge_CollectionAddedOnBothBranches reproduces workspace-d1b: merging a
+// collection that was created independently on both branches (so it is absent
+// from the merge base) must not crash. The base collection hash for such a
+// collection is the zero hash, and the 3-way collection merge must treat the
+// missing base as an empty map rather than trying to open it.
+//
+// Before the fix this fails with:
+//
+//	DumboDBMerge: opening base collection "items": unexpected file ID "" for
+//	collection (want DTBL or TUPM)
+func TestMerge_CollectionAddedOnBothBranches(t *testing.T) {
+	env := startDumboDB(t)
+	ctx := context.Background()
+	dbName := fmt.Sprintf("mergeadd_%d", rand.Int64N(1_000_000))
+
+	// Base commit A: only "item" exists here. This is the merge base.
+	base := env.Client.Database(dbName)
+	require.NoError(t, base.Drop(ctx))
+	_, err := base.Collection("item").InsertOne(ctx,
+		bson.D{{Key: "_id", Value: int32(1)}, {Key: "v", Value: "base"}})
+	require.NoError(t, err)
+	dumboDBCommit(t, env, dbName, "A: base with item", "alice <a@x.io>")
+
+	// Branch featureA from main at A.
+	mainDB := env.Client.Database(dbName + "@main")
+	featDB := env.Client.Database(dbName + "@featureA")
+	require.NoError(t, mainDB.RunCommand(ctx, bson.D{
+		{Key: "doltBranch", Value: int32(1)}, {Key: "branch", Value: "featureA"},
+	}).Err())
+
+	// main independently creates a NEW collection "items" (absent in base A).
+	_, err = mainDB.Collection("items").InsertOne(ctx,
+		bson.D{{Key: "_id", Value: int32(10)}, {Key: "side", Value: "main"}})
+	require.NoError(t, err)
+	dumboDBCommit(t, env, dbName+"@main", "main: add items/10", "alice <a@x.io>")
+
+	// featureA independently creates the SAME new collection "items" with a
+	// different _id, so the merge itself is conflict-free once the empty base is
+	// handled.
+	_, err = featDB.Collection("items").InsertOne(ctx,
+		bson.D{{Key: "_id", Value: int32(20)}, {Key: "side", Value: "featureA"}})
+	require.NoError(t, err)
+	dumboDBCommit(t, env, dbName+"@featureA", "featureA: add items/20", "bob <b@x.io>")
+
+	// Merge featureA into main. "items" was added on both sides and is absent
+	// from base A, so its base collection hash is empty.
+	var res bson.M
+	err = mainDB.RunCommand(ctx, bson.D{
+		{Key: "doltMerge", Value: int32(1)},
+		{Key: "merge_in", Value: "featureA"},
+		{Key: "message", Value: "merge featureA into main"},
+		{Key: "author", Value: "alice <a@x.io>"},
+	}).Decode(&res)
+	require.NoError(t, err, "merging a collection added on both branches must not error")
+	assert.EqualValues(t, 1, res["ok"])
+
+	// Both independently-added documents survive the merge.
+	require.NoError(t, mainDB.Collection("items").FindOne(ctx,
+		bson.D{{Key: "_id", Value: int32(10)}}).Err(), "main's items/10 must survive")
+	require.NoError(t, mainDB.Collection("items").FindOne(ctx,
+		bson.D{{Key: "_id", Value: int32(20)}}).Err(), "featureA's items/20 must survive")
+}


### PR DESCRIPTION
There was a gap in the merge code where if each branch created a collection with the same name but no conflicting documents, the follow error occurred:

`DumboDBMerge: opening base collection "items": unexpected file ID "" for collection (want DTBL or TUPM)`