### PR TITLE
reset support on non-main branch

### DIFF
--- a/docs/verify/reset.md
+++ b/docs/verify/reset.md
@@ -186,11 +186,13 @@ db.tasks.find()
 // Expected: only the documents present in the HEAD commit
 ```
 
-Finally, a bare soft reset  -- `{ doltReset: 1 }` with neither `to` nor `hard`  --
-defaults to HEAD and is a no-op in effect: HEAD stays the same and the working tree
-stays the same. It is still valid and returns the current HEAD hash.
+Finally, a soft reset to HEAD  -- `{ doltReset: 1 }` with neither `to` nor `hard`  --
+must have no effect on uncommitted edits: HEAD stays the same and the working tree is
+preserved. Introduce an uncommitted insert, then soft-reset to HEAD:
 
 ```js
+db.tasks.insertOne({ _id: 6, v: 6 })   // uncommitted edit
+
 const rSoft = db.runCommand({ doltReset: 1 })
 printjson(rSoft)
 // Expected: { commitId: "<current HEAD hash>", ok: 1 }
@@ -198,14 +200,22 @@ printjson(rSoft)
 
 Key checks:
 - `commitId` equals the current HEAD hash (unchanged)
-- The working set is unperturbed:
+- The uncommitted edit survives  -- the working tree is untouched:
 
 ```js
 db.runCommand({ doltDiff: 1 })
-// Expected: { "collections": [], "ok": 1 }
+// Expected: tasks.added still contains _id:6
 
 db.tasks.find()
-// Expected: still only the documents present in the HEAD commit
+// Expected: the HEAD documents plus the uncommitted _id:6
+```
+
+A hard reset to HEAD then discards that same edit, restoring the clean HEAD state:
+
+```js
+db.runCommand({ doltReset: 1, hard: true })
+db.tasks.find()
+// Expected: only the documents present in the HEAD commit (the _id:6 edit is gone)
 ```
 
 ---

--- a/docs/verify/reset.md
+++ b/docs/verify/reset.md
@@ -410,6 +410,29 @@ fdb.tasks.find()                                      // Expected: _id:1, _id:2,
 
 ---
 
+## Scenario 10: Reset is rejected on a read-only connection
+
+A connection whose rootish is a commit hash or an ancestor/caret expression
+(`db@<hash>`, `db@main~1`) is a read-only snapshot with no branch to move. `doltReset`
+must be refused rather than treating the rootish as a branch name.
+
+```js
+var sdb = db.getSiblingDB("resetbranchdb@" + hashF1)   // commit-hash snapshot
+sdb.runCommand({ doltReset: 1, to: hashF1 })
+// Expected: command error, code 96 (OperationFailed): cannot write to a read-only database snapshot
+
+sdb.runCommand({ doltReset: 1, to: hashF1, hard: true })
+// Expected: same OperationFailed error
+
+var adb = db.getSiblingDB("resetbranchdb@feature~1")   // ancestor-expression snapshot
+adb.runCommand({ doltReset: 1, to: hashF1 })
+// Expected: same OperationFailed error
+```
+
+Neither `main` nor `feature` moves, and no stray branch is created.
+
+---
+
 ## Quick Reference
 
 | Command | HEAD after | Working set after |

--- a/docs/verify/reset.md
+++ b/docs/verify/reset.md
@@ -343,6 +343,73 @@ mdb.tasks.find()                                      // Expected: _id:1 only (1
 
 ---
 
+## Scenario 8: Hard reset to a commit on another branch  -- content follows the target
+
+`to` may name any commit in the repo, including one that lives on a different branch.
+Resetting `main` to a feature-branch commit moves `main` to that commit; a hard reset
+also makes `main`'s content follow the target. The feature branch is untouched.
+
+Rebuild the branch setup, then, on the `main` connection, hard-reset to F1:
+
+```js
+const rHard = mdb.runCommand({ doltReset: 1, to: hashF1, hard: true })
+printjson(rHard)
+// Expected: { commitId: "<hashF1>", ok: 1 }
+```
+
+Key checks:
+- `commitId` equals `hashF1`
+- **main** now follows F1's content, including `_id:2` which was only ever committed
+  on the feature branch; `_id:3` (only on F2) is absent, and the working set is clean:
+
+```js
+mdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashF1
+mdb.tasks.find()                                      // Expected: _id:1 and _id:2 (2 docs)
+mdb.runCommand({ doltDiff: 1 })                       // Expected: { collections: [], ok: 1 }
+```
+
+- **feature** is untouched: its HEAD is still F2 and all three docs are present.
+
+```js
+fdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashF2 (unchanged)
+fdb.tasks.find()                                      // Expected: _id:1, _id:2, _id:3 (3 docs)
+```
+
+---
+
+## Scenario 9: Soft reset to a commit on another branch  -- diff reflects the gap
+
+A soft reset to a cross-branch commit moves HEAD but preserves `main`'s working tree.
+The resulting diff therefore compares the new HEAD against the unchanged working tree.
+
+Rebuild the branch setup, then, on the `main` connection, soft-reset to F1:
+
+```js
+const rSoft = mdb.runCommand({ doltReset: 1, to: hashF1 })
+printjson(rSoft)
+// Expected: { commitId: "<hashF1>", ok: 1 }
+```
+
+Key checks:
+- `commitId` equals `hashF1`; `main` HEAD is now F1
+- `main`'s working tree is preserved at M1 (only `_id:1`), so relative to the new HEAD
+  (F1 = `{_id:1, _id:2}`) the working tree is missing `_id:2`  -- it shows as removed:
+
+```js
+mdb.tasks.find()               // Expected: _id:1 only (working tree unchanged)
+mdb.runCommand({ doltDiff: 1 })
+// Expected: tasks.removed contains exactly _id:2; added and modified are empty
+```
+
+- **feature** is untouched: its HEAD is still F2 and all three docs are present.
+
+```js
+fdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashF2 (unchanged)
+fdb.tasks.find()                                      // Expected: _id:1, _id:2, _id:3 (3 docs)
+```
+
+---
+
 ## Quick Reference
 
 | Command | HEAD after | Working set after |

--- a/docs/verify/reset.md
+++ b/docs/verify/reset.md
@@ -33,13 +33,13 @@ db.dropDatabase()
 db.tasks.insertOne({ _id: 1, v: 1 })
 const r1 = db.runCommand({ doltCommit: 1, message: "initial", author: "alice <alice@acme.com>" })
 printjson(r1)
-// Expected: { hash: "<hashC1>", branch: "main", message: "initial", ok: 1 }
+// Expected: { commitId: "<hashC1>", branch: "main", message: "initial", ok: 1, ... }
 const hashC1 = r1.commitId
 
 db.tasks.insertOne({ _id: 2, v: 2 })
 const r2 = db.runCommand({ doltCommit: 1, message: "add-two", author: "bob <bob@widgets.io>" })
 printjson(r2)
-// Expected: { hash: "<hashC2>", branch: "main", message: "add-two", ok: 1 }
+// Expected: { commitId: "<hashC2>", branch: "main", message: "add-two", ok: 1, ... }
 const hashC2 = r2.commitId
 
 print("hashC1 =", hashC1)
@@ -65,11 +65,11 @@ db.tasks.insertOne({ _id: 3, v: 3 })
 // Soft reset to hashC1 (no `hard` parameter  -- defaults to false).
 const rReset = db.runCommand({ doltReset: 1, to: hashC1 })
 printjson(rReset)
-// Expected: { hash: "<hashC1>", ok: 1 }
+// Expected: { commitId: "<hashC1>", ok: 1 }
 ```
 
 Key checks:
-- `hash` in the response equals `hashC1`
+- `commitId` in the response equals `hashC1`
 
 After the reset, HEAD is at C1 (which contains only `_id:1`). The working set is
 unchanged and still contains `_id:1`, `_id:2`, and `_id:3`. Diffing HEAD vs the
@@ -100,11 +100,11 @@ db.tasks.insertOne({ _id: 4, v: 4 })
 // Hard reset to hashC1.
 const rHard = db.runCommand({ doltReset: 1, to: hashC1, hard: true })
 printjson(rHard)
-// Expected: { hash: "<hashC1>", ok: 1 }
+// Expected: { commitId: "<hashC1>", ok: 1 }
 ```
 
 Key checks:
-- `hash` in the response equals `hashC1`
+- `commitId` in the response equals `hashC1`
 
 After the hard reset, both HEAD and the working set reflect the C1 state:
 
@@ -137,7 +137,7 @@ const hashC4 = r4.commitId
 
 // Soft reset to C1  -- this "undoes" the C4 commit.
 db.runCommand({ doltReset: 1, to: hashC1 })
-// Expected: { hash: "<hashC1>", ok: 1 }
+// Expected: { commitId: "<hashC1>", ok: 1 }
 ```
 
 After this soft reset:
@@ -186,8 +186,27 @@ db.tasks.find()
 // Expected: only the documents present in the HEAD commit
 ```
 
-A soft reset to HEAD is a no-op in effect (HEAD stays the same, working tree
-stays the same), but is valid and returns the HEAD hash.
+Finally, a bare soft reset  -- `{ doltReset: 1 }` with neither `to` nor `hard`  --
+defaults to HEAD and is a no-op in effect: HEAD stays the same and the working tree
+stays the same. It is still valid and returns the current HEAD hash.
+
+```js
+const rSoft = db.runCommand({ doltReset: 1 })
+printjson(rSoft)
+// Expected: { commitId: "<current HEAD hash>", ok: 1 }
+```
+
+Key checks:
+- `commitId` equals the current HEAD hash (unchanged)
+- The working set is unperturbed:
+
+```js
+db.runCommand({ doltDiff: 1 })
+// Expected: { "collections": [], "ok": 1 }
+
+db.tasks.find()
+// Expected: still only the documents present in the HEAD commit
+```
 
 ---
 
@@ -216,6 +235,101 @@ Accepted forms for `to`:
 - Relative ancestor expression (`<branch>~N`)
 - `HEAD` (alias for the connection's branch HEAD)
 - `HEAD~N` (Nth first-parent ancestor of the connection's branch HEAD)
+
+---
+
+## Branch setup (Scenarios 6 and 7)
+
+`doltReset` acts on the branch encoded in the connection (`db@branch`), not on
+`main`. Resetting a feature branch must move that branch's HEAD (and, when hard,
+its working set); `main` must be left completely untouched.
+
+Both branch scenarios use a fresh database so the two histories are unambiguous.
+Run this setup once before each scenario (drop and rebuild for a clean state).
+
+```js
+var mdb = db.getSiblingDB("resetbranchdb")
+mdb.dropDatabase()
+
+// main: one committed document (M1).
+mdb.tasks.insertOne({ _id: 1, v: 1 })
+const hashM1 = mdb.runCommand({ doltCommit: 1, message: "main-base", author: "alice <alice@acme.com>" }).commitId
+
+// Create a feature branch from main.
+mdb.runCommand({ doltBranch: 1, branch: "feature" })
+
+// Switch to the feature branch and add two commits (F1, F2).
+var fdb = db.getSiblingDB("resetbranchdb@feature")
+fdb.tasks.insertOne({ _id: 2, v: 2 })
+const hashF1 = fdb.runCommand({ doltCommit: 1, message: "feature-one", author: "carol <carol@acme.com>" }).commitId
+
+fdb.tasks.insertOne({ _id: 3, v: 3 })
+const hashF2 = fdb.runCommand({ doltCommit: 1, message: "feature-two", author: "carol <carol@acme.com>" }).commitId
+```
+
+After setup:
+- **main** (`hashM1`): `tasks` = `[ { _id: 1 } ]`
+- **feature** (`hashF2`, HEAD): `tasks` = `[ { _id: 1 }, { _id: 2 }, { _id: 3 } ]`
+
+---
+
+## Scenario 6: Soft reset on a non-main branch  -- only the target branch moves
+
+Rebuild the branch setup, then soft-reset the feature branch back to F1. HEAD moves
+but the working tree is preserved, so `_id:3` becomes an uncommitted addition. `main`
+must be untouched.
+
+```js
+const rSoft = fdb.runCommand({ doltReset: 1, to: hashF1 })
+printjson(rSoft)
+// Expected: { commitId: "<hashF1>", ok: 1 }
+```
+
+Key checks:
+- `commitId` equals `hashF1`
+- The **feature** branch moved to F1 but its working tree is preserved:
+
+```js
+fdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashF1
+fdb.tasks.find()                                      // Expected: _id:1, _id:2, _id:3 (3 docs)
+fdb.runCommand({ doltDiff: 1 })                       // Expected: tasks.added contains exactly _id:3
+```
+
+- **main** is untouched: its HEAD is still M1 and only `_id:1` is visible.
+
+```js
+mdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashM1 (unchanged)
+mdb.tasks.find()                                      // Expected: _id:1 only (1 doc)
+```
+
+---
+
+## Scenario 7: Hard reset on a non-main branch  -- only the target branch moves
+
+Rebuild the branch setup, then hard-reset the feature branch back to F1. Both HEAD
+and the working set return to the F1 state. `main` must be untouched.
+
+```js
+const rHard = fdb.runCommand({ doltReset: 1, to: hashF1, hard: true })
+printjson(rHard)
+// Expected: { commitId: "<hashF1>", ok: 1 }
+```
+
+Key checks:
+- `commitId` equals `hashF1`
+- The **feature** branch moved: its HEAD is F1 and only `_id:1`, `_id:2` are visible.
+
+```js
+fdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashF1
+fdb.tasks.find()                                      // Expected: _id:1 and _id:2 only (2 docs)
+```
+
+- **main** is untouched: its HEAD is still M1 and only `_id:1` is visible.
+
+```js
+mdb.runCommand({ doltLog: 1 }).commits[0].commitId   // Expected: hashM1 (unchanged)
+mdb.tasks.find()                                      // Expected: _id:1 only (1 doc)
+```
 
 ---
 

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -2724,14 +2724,12 @@ func (b *Backend) DumboDBReset(ctx context.Context, params *backends.ResetParams
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	// Reset operates on the branch encoded in the connection, not necessarily main.
 	branch := params.Branch
 	if branch == "" {
 		branch = defaultBranch
 	}
 	branchDataset := "refs/heads/" + branch
 
-	// Resolve empty CommitID to the current HEAD of the target branch.
 	commitID := params.CommitID
 	if commitID == "" {
 		branchDS, dsErr := db.datasDB.GetDataset(ctx, branchDataset)
@@ -2756,7 +2754,6 @@ func (b *Backend) DumboDBReset(ctx context.Context, params *backends.ResetParams
 		return nil, fmt.Errorf("DumboDBReset: resolving target commit %q: %w", commitID, err)
 	}
 
-	// Move the branch HEAD to the target commit without touching the working set.
 	branchDS, dsErr := db.datasDB.GetDataset(ctx, branchDataset)
 	if dsErr != nil {
 		return nil, fmt.Errorf("DumboDBReset: resolving branch %q for db %q: %w", branch, params.DBName, dsErr)

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -2724,16 +2724,23 @@ func (b *Backend) DumboDBReset(ctx context.Context, params *backends.ResetParams
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	// Resolve empty CommitID to the current HEAD.
+	// Reset operates on the branch encoded in the connection, not necessarily main.
+	branch := params.Branch
+	if branch == "" {
+		branch = defaultBranch
+	}
+	branchDataset := "refs/heads/" + branch
+
+	// Resolve empty CommitID to the current HEAD of the target branch.
 	commitID := params.CommitID
 	if commitID == "" {
-		mainDS, dsErr := db.datasDB.GetDataset(ctx, mainDataset)
+		branchDS, dsErr := db.datasDB.GetDataset(ctx, branchDataset)
 		if dsErr != nil {
-			return nil, fmt.Errorf("DumboDBReset: resolving main dataset for db %q: %w", params.DBName, dsErr)
+			return nil, fmt.Errorf("DumboDBReset: resolving branch %q for db %q: %w", branch, params.DBName, dsErr)
 		}
-		headHash, ok := mainDS.MaybeHeadAddr()
+		headHash, ok := branchDS.MaybeHeadAddr()
 		if !ok {
-			return nil, fmt.Errorf("DumboDBReset: no HEAD commit for db %q", params.DBName)
+			return nil, fmt.Errorf("DumboDBReset: no HEAD commit for branch %q in db %q", branch, params.DBName)
 		}
 		commitID = headHash.String()
 	}
@@ -2749,39 +2756,39 @@ func (b *Backend) DumboDBReset(ctx context.Context, params *backends.ResetParams
 		return nil, fmt.Errorf("DumboDBReset: resolving target commit %q: %w", commitID, err)
 	}
 
-	// Move HEAD to the target commit without touching the working set.
-	mainDS, dsErr := db.datasDB.GetDataset(ctx, mainDataset)
+	// Move the branch HEAD to the target commit without touching the working set.
+	branchDS, dsErr := db.datasDB.GetDataset(ctx, branchDataset)
 	if dsErr != nil {
-		return nil, fmt.Errorf("DumboDBReset: resolving main dataset for db %q: %w", params.DBName, dsErr)
+		return nil, fmt.Errorf("DumboDBReset: resolving branch %q for db %q: %w", branch, params.DBName, dsErr)
 	}
-	if _, err := db.datasDB.SetHead(ctx, mainDS, targetHash, ""); err != nil {
-		return nil, fmt.Errorf("DumboDBReset: setting HEAD to %q: %w", commitID, err)
+	if _, err := db.datasDB.SetHead(ctx, branchDS, targetHash, ""); err != nil {
+		return nil, fmt.Errorf("DumboDBReset: setting HEAD for branch %q to %q: %w", branch, commitID, err)
 	}
 
 	if params.Hard {
 		// Hard reset: working tree and staged root both point to the target commit.
-		if err := db.persistAM(ctx, defaultBranch, targetAM); err != nil {
-			return nil, fmt.Errorf("DumboDBReset: updating working set (hard): %w", err)
+		if err := db.persistAM(ctx, branch, targetAM); err != nil {
+			return nil, fmt.Errorf("DumboDBReset: updating working set (hard) for branch %q: %w", branch, err)
 		}
-		db.setAM(ctx, defaultBranch, targetAM)
+		db.setAM(ctx, branch, targetAM)
 	} else {
 		// Soft reset: keep working tree, change staged to target commit.
 		stagedRV, stagedErr := amToRootValue(ctx, db, targetAM)
 		if stagedErr != nil {
 			return nil, fmt.Errorf("DumboDBReset (soft): building staged root: %w", stagedErr)
 		}
-		fallbackWS, fbErr := db.loadBranchWS(ctx, defaultBranch)
+		fallbackWS, fbErr := db.loadBranchWS(ctx, branch)
 		if fbErr != nil {
-			return nil, fmt.Errorf("DumboDBReset (soft): loading working set: %w", fbErr)
+			return nil, fmt.Errorf("DumboDBReset (soft): loading working set for branch %q: %w", branch, fbErr)
 		}
-		ws, wsErr := workingSetViaSession(ctx, sessionFromContext(ctx), fallbackWS, params.DBName, defaultBranch)
+		ws, wsErr := workingSetViaSession(ctx, sessionFromContext(ctx), fallbackWS, params.DBName, branch)
 		if wsErr != nil {
-			return nil, fmt.Errorf("DumboDBReset (soft): reading working set: %w", wsErr)
+			return nil, fmt.Errorf("DumboDBReset (soft): reading working set for branch %q: %w", branch, wsErr)
 		}
-		if err := db.updateBranchWS(ctx, defaultBranch, func(_ *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
+		if err := db.updateBranchWS(ctx, branch, func(_ *doltdb.WorkingSet) (*doltdb.WorkingSet, error) {
 			return ws.WithStagedRoot(stagedRV), nil
 		}); err != nil {
-			return nil, fmt.Errorf("DumboDBReset: updating working set (soft): %w", err)
+			return nil, fmt.Errorf("DumboDBReset: updating working set (soft) for branch %q: %w", branch, err)
 		}
 	}
 

--- a/internal/handler/msg_dumbodb_versioning.go
+++ b/internal/handler/msg_dumbodb_versioning.go
@@ -1490,6 +1490,13 @@ func (h *Handler) MsgDumboDBReset(connCtx context.Context, msg *wire.OpMsg) (*wi
 		return nil, err
 	}
 
+	// Reset moves a branch HEAD and working set; it requires a writable branch.
+	// Reject read-only connections (commit hash, ancestor/caret rootish) before
+	// deriving the branch, so we never treat a rootish as a branch name.
+	if err := enforceWritableRootish(encodedDB); err != nil {
+		return nil, err
+	}
+
 	dbName, branch, _, err := branchFromDBName(encodedDB)
 	if err != nil {
 		return nil, err

--- a/internal/handler/msg_dumbodb_versioning.go
+++ b/internal/handler/msg_dumbodb_versioning.go
@@ -1490,9 +1490,6 @@ func (h *Handler) MsgDumboDBReset(connCtx context.Context, msg *wire.OpMsg) (*wi
 		return nil, err
 	}
 
-	// Reset moves a branch HEAD and working set; it requires a writable branch.
-	// Reject read-only connections (commit hash, ancestor/caret rootish) before
-	// deriving the branch, so we never treat a rootish as a branch name.
 	if err := enforceWritableRootish(encodedDB); err != nil {
 		return nil, err
 	}

--- a/tests/verify/reset_test.go
+++ b/tests/verify/reset_test.go
@@ -64,8 +64,6 @@ func resetVerifySetup(t *testing.T, env *dumboDBTestEnv, dbName string) (hashC1,
 	return hashC1, hashC2
 }
 
-// branchHead returns the HEAD commit hash for a connection db, which may encode a
-// branch as "db@branch".
 func branchHead(t *testing.T, env *dumboDBTestEnv, connDB string) string {
 	t.Helper()
 
@@ -83,8 +81,6 @@ func branchHead(t *testing.T, env *dumboDBTestEnv, connDB string) string {
 	return h
 }
 
-// resetBranchVerifySetup creates a fresh database with main at M1 and a feature
-// branch carrying two extra commits F1 and F2. Returns the db name and hashes.
 func resetBranchVerifySetup(t *testing.T, env *dumboDBTestEnv) (brDB, hashM1, hashF1, hashF2 string) {
 	t.Helper()
 	ctx := context.Background()
@@ -93,14 +89,12 @@ func resetBranchVerifySetup(t *testing.T, env *dumboDBTestEnv) (brDB, hashM1, ha
 	mainDB := env.Client.Database(brDB)
 	require.NoError(t, mainDB.Drop(ctx))
 
-	// main: one committed document (M1).
 	_, err := mainDB.Collection("tasks").InsertOne(ctx, bson.D{
 		{Key: "_id", Value: int32(1)}, {Key: "v", Value: int32(1)},
 	})
 	require.NoError(t, err)
 	hashM1 = dumboDBCommit(t, env, brDB, "main-base", "alice <alice@acme.com>")
 
-	// Create a feature branch from main, then add two commits on it (F1, F2).
 	bsBranchCreate(t, env, brDB, "main", "feature")
 	featDB := env.Client.Database(brDB + "@feature")
 
@@ -287,9 +281,6 @@ func TestResetVerify(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Pre-check (mirrors the doc): the uncommitted _id:5 must show as a working-set
-		// change (doltDiff = HEAD vs working set) before we discard it, so an empty
-		// diff after reset is meaningful.
 		var preDiffRaw bson.M
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
 			{Key: "doltDiff", Value: int32(1)},
@@ -328,9 +319,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(1), n,
 			"after hard reset to HEAD: exactly 1 document must be visible")
 
-		// Soft reset to HEAD must have NO effect on uncommitted edits. Introduce an
-		// uncommitted insert (_id:6), then bare soft reset {doltReset:1} (no `to`, no
-		// `hard`, defaults to HEAD), and confirm the edit survives.
 		_, err = items.InsertOne(ctx, bson.D{
 			{Key: "_id", Value: int32(6)},
 			{Key: "v", Value: int32(6)},
@@ -344,7 +332,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, headHash, softRaw["commitId"], "bare soft reset must return current HEAD hash")
 		assert.EqualValues(t, 1, softRaw["ok"], "bare soft reset must report ok:1")
 
-		// Working tree is untouched: _id:6 is still an uncommitted addition.
 		var softDiffRaw bson.M
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
 			{Key: "doltDiff", Value: int32(1)},
@@ -357,8 +344,6 @@ func TestResetVerify(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), n, "soft reset to HEAD must not remove the uncommitted _id:6")
 
-		// A hard reset to HEAD then discards that same edit, restoring the clean
-		// HEAD=C1 state (also the precondition Scenario 5 relies on).
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
 			{Key: "doltReset", Value: int32(1)},
 			{Key: "hard", Value: true},
@@ -432,15 +417,10 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, hashC5, raw["commitId"], "to:'main' must return main's HEAD")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 6: Soft reset on a non-main branch  -- only the target branch moves
-	// -------------------------------------------------------------------------
 	t.Run("Scenario6_SoftResetOnNonMainBranch", func(t *testing.T) {
 		brDB, hashM1, hashF1, _ := resetBranchVerifySetup(t, env)
 		featDB := env.Client.Database(brDB + "@feature")
 
-		// Soft-reset feature back to F1 (no `hard`): feature HEAD moves to F1 but
-		// the working tree is preserved, so _id:3 becomes an uncommitted addition.
 		var raw bson.M
 		require.NoError(t, featDB.RunCommand(ctx, bson.D{
 			{Key: "doltReset", Value: int32(1)},
@@ -449,7 +429,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, hashF1, raw["commitId"], "soft reset on feature must resolve to F1")
 		assert.EqualValues(t, 1, raw["ok"])
 
-		// feature: HEAD moved to F1, working tree preserved (still _id:1,2,3).
 		assert.Equal(t, hashF1, branchHead(t, env, brDB+"@feature"),
 			"feature HEAD must be F1 after soft reset on feature")
 		fn, err := featDB.Collection("tasks").CountDocuments(ctx, bson.D{})
@@ -457,7 +436,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(3), fn,
 			"soft reset preserves the feature working tree (_id:1,2,3)")
 
-		// feature diff: HEAD=F1 vs working set shows _id:3 as the only addition.
 		var diffRaw bson.M
 		require.NoError(t, featDB.RunCommand(ctx, bson.D{
 			{Key: "doltDiff", Value: int32(1)},
@@ -467,7 +445,6 @@ func TestResetVerify(t *testing.T) {
 		require.Len(t, cd.Added, 1, "exactly _id:3 should be uncommitted after soft reset to F1")
 		assert.Equal(t, int32(3), cd.Added[0]["_id"], "the uncommitted addition must be _id:3")
 
-		// main must be completely untouched: HEAD=M1, working set = {_id:1}.
 		assert.Equal(t, hashM1, branchHead(t, env, brDB),
 			"main HEAD must be unchanged by a soft reset on feature")
 		mn, err := env.Client.Database(brDB).Collection("tasks").CountDocuments(ctx, bson.D{})
@@ -476,14 +453,10 @@ func TestResetVerify(t *testing.T) {
 			"main working set must be untouched by a soft reset on feature")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 7: Hard reset on a non-main branch  -- only the target branch moves
-	// -------------------------------------------------------------------------
 	t.Run("Scenario7_HardResetOnNonMainBranch", func(t *testing.T) {
 		brDB, hashM1, hashF1, _ := resetBranchVerifySetup(t, env)
 		featDB := env.Client.Database(brDB + "@feature")
 
-		// Hard-reset the feature branch back to F1.
 		var raw bson.M
 		require.NoError(t, featDB.RunCommand(ctx, bson.D{
 			{Key: "doltReset", Value: int32(1)},
@@ -493,7 +466,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, hashF1, raw["commitId"], "hard reset on feature must resolve to F1")
 		assert.EqualValues(t, 1, raw["ok"])
 
-		// feature: HEAD=F1 and working set reset to {_id:1,_id:2}.
 		assert.Equal(t, hashF1, branchHead(t, env, brDB+"@feature"),
 			"feature HEAD must be F1 after hard reset on feature")
 		fn, err := featDB.Collection("tasks").CountDocuments(ctx, bson.D{})
@@ -501,7 +473,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(2), fn,
 			"feature working set must show 2 docs (_id:1,2) after hard reset to F1")
 
-		// main must be completely untouched: HEAD=M1, working set = {_id:1}.
 		assert.Equal(t, hashM1, branchHead(t, env, brDB),
 			"main HEAD must be unchanged by a hard reset on feature")
 		mn, err := env.Client.Database(brDB).Collection("tasks").CountDocuments(ctx, bson.D{})
@@ -510,15 +481,11 @@ func TestResetVerify(t *testing.T) {
 			"main working set must be untouched (only _id:1) by a hard reset on feature")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 8: Hard reset to a commit on another branch  -- content follows target
-	// -------------------------------------------------------------------------
 	t.Run("Scenario8_HardResetToCommitOnOtherBranch", func(t *testing.T) {
 		brDB, _, hashF1, hashF2 := resetBranchVerifySetup(t, env)
 		mainDB := env.Client.Database(brDB)
 		tasks := mainDB.Collection("tasks")
 
-		// On main, hard-reset to F1  -- a commit that lives on the feature branch.
 		var raw bson.M
 		require.NoError(t, mainDB.RunCommand(ctx, bson.D{
 			{Key: "doltReset", Value: int32(1)},
@@ -528,8 +495,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, hashF1, raw["commitId"], "reset must resolve to the feature commit F1")
 		assert.EqualValues(t, 1, raw["ok"])
 
-		// main HEAD moved to F1 and its content now follows the target: {_id:1,_id:2},
-		// including _id:2 which was only ever committed on the feature branch.
 		assert.Equal(t, hashF1, branchHead(t, env, brDB), "main HEAD must be F1 after hard reset")
 		mn, err := tasks.CountDocuments(ctx, bson.D{})
 		require.NoError(t, err)
@@ -541,13 +506,11 @@ func TestResetVerify(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), got3, "_id:3 (only on F2) must not be present after reset to F1")
 
-		// Working set matches the new HEAD  -- diff is empty.
 		var diffRaw bson.M
 		require.NoError(t, mainDB.RunCommand(ctx, bson.D{{Key: "doltDiff", Value: int32(1)}}).Decode(&diffRaw))
 		assert.Empty(t, decodeDiffResult(t, diffRaw).Collections,
 			"after hard reset the working set must match HEAD (empty diff)")
 
-		// The feature branch is untouched: HEAD still F2, still 3 docs.
 		assert.Equal(t, hashF2, branchHead(t, env, brDB+"@feature"),
 			"feature HEAD must be unchanged by a reset on main")
 		fn, err := env.Client.Database(brDB+"@feature").Collection("tasks").CountDocuments(ctx, bson.D{})
@@ -555,16 +518,11 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(3), fn, "feature content must be unchanged (3 docs)")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 9: Soft reset to a commit on another branch  -- diff reflects the gap
-	// -------------------------------------------------------------------------
 	t.Run("Scenario9_SoftResetToCommitOnOtherBranch", func(t *testing.T) {
 		brDB, _, hashF1, hashF2 := resetBranchVerifySetup(t, env)
 		mainDB := env.Client.Database(brDB)
 		tasks := mainDB.Collection("tasks")
 
-		// On main, soft-reset to F1 (a feature-branch commit). HEAD moves to F1 but
-		// main's working tree (still M1 = {_id:1}) is preserved.
 		var raw bson.M
 		require.NoError(t, mainDB.RunCommand(ctx, bson.D{
 			{Key: "doltReset", Value: int32(1)},
@@ -574,13 +532,10 @@ func TestResetVerify(t *testing.T) {
 		assert.EqualValues(t, 1, raw["ok"])
 		assert.Equal(t, hashF1, branchHead(t, env, brDB), "main HEAD must be F1 after soft reset")
 
-		// Working tree preserved at M1: only _id:1 is visible.
 		mn, err := tasks.CountDocuments(ctx, bson.D{})
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), mn, "soft reset preserves main's working tree (_id:1 only)")
 
-		// The diff makes sense: the new HEAD F1 has {_id:1,_id:2} but the working
-		// tree has only {_id:1}, so _id:2 shows as removed relative to the new HEAD.
 		var diffRaw bson.M
 		require.NoError(t, mainDB.RunCommand(ctx, bson.D{{Key: "doltDiff", Value: int32(1)}}).Decode(&diffRaw))
 		cd := findCollDiff(decodeDiffResult(t, diffRaw), "tasks")
@@ -590,7 +545,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Empty(t, cd.Added, "no docs should be added")
 		assert.Empty(t, cd.Modified, "no docs should be modified")
 
-		// The feature branch is untouched: HEAD still F2, still 3 docs.
 		assert.Equal(t, hashF2, branchHead(t, env, brDB+"@feature"),
 			"feature HEAD must be unchanged by a reset on main")
 		fn, err := env.Client.Database(brDB+"@feature").Collection("tasks").CountDocuments(ctx, bson.D{})
@@ -598,16 +552,9 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(3), fn, "feature content must be unchanged (3 docs)")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 10: Reset is rejected on a read-only connection (no branch to move)
-	// -------------------------------------------------------------------------
 	t.Run("Scenario10_ResetRejectedOnReadOnlyConnection", func(t *testing.T) {
 		brDB, hashM1, hashF1, hashF2 := resetBranchVerifySetup(t, env)
 
-		// A commit-hash connection and an ancestor-expression connection are both
-		// read-only snapshots with no branch to move; reset must be refused rather
-		// than treating the rootish as a branch name (which would create a stray
-		// refs/heads/<rootish>).
 		readOnlyConns := []string{brDB + "@" + hashF1, brDB + "@feature~1"}
 		for _, conn := range readOnlyConns {
 			db := env.Client.Database(conn)
@@ -626,7 +573,6 @@ func TestResetVerify(t *testing.T) {
 			assertWriteBlockedOperationFailed(t, hardErr, "hard doltReset on "+conn)
 		}
 
-		// Nothing moved: main and feature HEADs are exactly as the setup left them.
 		assert.Equal(t, hashM1, branchHead(t, env, brDB), "main HEAD must be unchanged")
 		assert.Equal(t, hashF2, branchHead(t, env, brDB+"@feature"), "feature HEAD must be unchanged")
 	})

--- a/tests/verify/reset_test.go
+++ b/tests/verify/reset_test.go
@@ -123,9 +123,6 @@ func TestResetVerify(t *testing.T) {
 
 	hashC1, _ := resetVerifySetup(t, env, dbName)
 
-	// -------------------------------------------------------------------------
-	// Scenario 1: Soft reset (default)  -- HEAD moves back, working set preserved
-	// -------------------------------------------------------------------------
 	t.Run("Scenario1_SoftReset_WorkingSetPreserved", func(t *testing.T) {
 		items := env.Client.Database(dbName).Collection("tasks")
 
@@ -170,9 +167,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Empty(t, cd.Modified, "no documents should be modified")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 2: Hard reset  -- HEAD and working set both reset to target
-	// -------------------------------------------------------------------------
 	t.Run("Scenario2_HardReset_WorkingSetDiscarded", func(t *testing.T) {
 		items := env.Client.Database(dbName).Collection("tasks")
 
@@ -215,9 +209,6 @@ func TestResetVerify(t *testing.T) {
 			"after hard reset to C1: exactly 1 document must be visible")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 3: Soft reset undoes a committed change  -- it becomes uncommitted
-	// -------------------------------------------------------------------------
 	t.Run("Scenario3_SoftReset_UndoCommit", func(t *testing.T) {
 		items := env.Client.Database(dbName).Collection("tasks")
 
@@ -255,9 +246,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Empty(t, cd.Modified, "no modified documents")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 4: Hard reset to HEAD (no `to`)  -- discards uncommitted changes
-	// -------------------------------------------------------------------------
 	t.Run("Scenario4_HardResetToHEAD_DiscardsUncommitted", func(t *testing.T) {
 		items := env.Client.Database(dbName).Collection("tasks")
 
@@ -353,9 +341,6 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(1), n, "hard reset to HEAD must discard the uncommitted _id:6")
 	})
 
-	// -------------------------------------------------------------------------
-	// Scenario 5: Reset accepts relative rootish (HEAD~N, branch~N)
-	// -------------------------------------------------------------------------
 	t.Run("Scenario5_RelativeRootish", func(t *testing.T) {
 		items := env.Client.Database(dbName).Collection("tasks")
 

--- a/tests/verify/reset_test.go
+++ b/tests/verify/reset_test.go
@@ -287,8 +287,9 @@ func TestResetVerify(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Pre-check (mirrors the doc): the uncommitted _id:5 must show as a staged
-		// change before we discard it, so an empty diff after reset is meaningful.
+		// Pre-check (mirrors the doc): the uncommitted _id:5 must show as a working-set
+		// change (doltDiff = HEAD vs working set) before we discard it, so an empty
+		// diff after reset is meaningful.
 		var preDiffRaw bson.M
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
 			{Key: "doltDiff", Value: int32(1)},
@@ -595,5 +596,38 @@ func TestResetVerify(t *testing.T) {
 		fn, err := env.Client.Database(brDB+"@feature").Collection("tasks").CountDocuments(ctx, bson.D{})
 		require.NoError(t, err)
 		assert.Equal(t, int64(3), fn, "feature content must be unchanged (3 docs)")
+	})
+
+	// -------------------------------------------------------------------------
+	// Scenario 10: Reset is rejected on a read-only connection (no branch to move)
+	// -------------------------------------------------------------------------
+	t.Run("Scenario10_ResetRejectedOnReadOnlyConnection", func(t *testing.T) {
+		brDB, hashM1, hashF1, hashF2 := resetBranchVerifySetup(t, env)
+
+		// A commit-hash connection and an ancestor-expression connection are both
+		// read-only snapshots with no branch to move; reset must be refused rather
+		// than treating the rootish as a branch name (which would create a stray
+		// refs/heads/<rootish>).
+		readOnlyConns := []string{brDB + "@" + hashF1, brDB + "@feature~1"}
+		for _, conn := range readOnlyConns {
+			db := env.Client.Database(conn)
+
+			softErr := db.RunCommand(ctx, bson.D{
+				{Key: "doltReset", Value: int32(1)},
+				{Key: "to", Value: hashF1},
+			}).Err()
+			assertWriteBlockedOperationFailed(t, softErr, "soft doltReset on "+conn)
+
+			hardErr := db.RunCommand(ctx, bson.D{
+				{Key: "doltReset", Value: int32(1)},
+				{Key: "to", Value: hashF1},
+				{Key: "hard", Value: true},
+			}).Err()
+			assertWriteBlockedOperationFailed(t, hardErr, "hard doltReset on "+conn)
+		}
+
+		// Nothing moved: main and feature HEADs are exactly as the setup left them.
+		assert.Equal(t, hashM1, branchHead(t, env, brDB), "main HEAD must be unchanged")
+		assert.Equal(t, hashF2, branchHead(t, env, brDB+"@feature"), "feature HEAD must be unchanged")
 	})
 }

--- a/tests/verify/reset_test.go
+++ b/tests/verify/reset_test.go
@@ -327,9 +327,15 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(1), n,
 			"after hard reset to HEAD: exactly 1 document must be visible")
 
-		// Bare soft reset {doltReset:1} (no `to`, no `hard`) defaults to HEAD and is
-		// a no-op in effect: HEAD unchanged, working tree unchanged. It must still
-		// succeed and return the current HEAD hash (doc Scenario 4 note + Quick Ref).
+		// Soft reset to HEAD must have NO effect on uncommitted edits. Introduce an
+		// uncommitted insert (_id:6), then bare soft reset {doltReset:1} (no `to`, no
+		// `hard`, defaults to HEAD), and confirm the edit survives.
+		_, err = items.InsertOne(ctx, bson.D{
+			{Key: "_id", Value: int32(6)},
+			{Key: "v", Value: int32(6)},
+		})
+		require.NoError(t, err)
+
 		var softRaw bson.M
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
 			{Key: "doltReset", Value: int32(1)},
@@ -337,18 +343,28 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, headHash, softRaw["commitId"], "bare soft reset must return current HEAD hash")
 		assert.EqualValues(t, 1, softRaw["ok"], "bare soft reset must report ok:1")
 
-		// The no-op soft reset must not perturb the working set: diff still empty,
-		// still only _id:1 visible.
+		// Working tree is untouched: _id:6 is still an uncommitted addition.
 		var softDiffRaw bson.M
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
 			{Key: "doltDiff", Value: int32(1)},
 		}).Decode(&softDiffRaw))
-		assert.Empty(t, decodeDiffResult(t, softDiffRaw).Collections,
-			"after bare soft reset to HEAD: diff must remain empty")
+		softCD := findCollDiff(decodeDiffResult(t, softDiffRaw), "tasks")
+		require.NotNil(t, softCD, "soft reset to HEAD must preserve the uncommitted _id:6 diff")
+		require.Len(t, softCD.Added, 1, "soft reset to HEAD must leave _id:6 as the only addition")
+		assert.Equal(t, int32(6), softCD.Added[0]["_id"], "the preserved addition must be _id:6")
 		n, err = items.CountDocuments(ctx, bson.D{})
 		require.NoError(t, err)
-		assert.Equal(t, int64(1), n,
-			"after bare soft reset to HEAD: exactly 1 document must be visible")
+		assert.Equal(t, int64(2), n, "soft reset to HEAD must not remove the uncommitted _id:6")
+
+		// A hard reset to HEAD then discards that same edit, restoring the clean
+		// HEAD=C1 state (also the precondition Scenario 5 relies on).
+		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
+			{Key: "doltReset", Value: int32(1)},
+			{Key: "hard", Value: true},
+		}).Decode(&softRaw))
+		n, err = items.CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n, "hard reset to HEAD must discard the uncommitted _id:6")
 	})
 
 	// -------------------------------------------------------------------------

--- a/tests/verify/reset_test.go
+++ b/tests/verify/reset_test.go
@@ -59,9 +59,65 @@ func resetVerifySetup(t *testing.T, env *dumboDBTestEnv, dbName string) (hashC1,
 		{Key: "v", Value: int32(2)},
 	})
 	require.NoError(t, err)
-	hashC2 = dumboDBCommit(t, env, dbName, "add-two", "alice <alice@acme.com>")
+	hashC2 = dumboDBCommit(t, env, dbName, "add-two", "bob <bob@widgets.io>")
 
 	return hashC1, hashC2
+}
+
+// branchHead returns the HEAD commit hash for a connection db, which may encode a
+// branch as "db@branch".
+func branchHead(t *testing.T, env *dumboDBTestEnv, connDB string) string {
+	t.Helper()
+
+	var logRaw bson.M
+	require.NoError(t, env.Client.Database(connDB).RunCommand(context.Background(), bson.D{
+		{Key: "doltLog", Value: int32(1)},
+	}).Decode(&logRaw))
+
+	commits, ok := logRaw["commits"].(bson.A)
+	require.True(t, ok && len(commits) > 0, "doltLog must return at least one commit for %q", connDB)
+	entry, ok := commits[0].(bson.M)
+	require.True(t, ok, "first log entry must be a document")
+	h, ok := entry["commitId"].(string)
+	require.True(t, ok && h != "", "first log entry must have a non-empty commitId")
+	return h
+}
+
+// resetBranchVerifySetup creates a fresh database with main at M1 and a feature
+// branch carrying two extra commits F1 and F2. Returns the db name and hashes.
+func resetBranchVerifySetup(t *testing.T, env *dumboDBTestEnv) (brDB, hashM1, hashF1, hashF2 string) {
+	t.Helper()
+	ctx := context.Background()
+
+	brDB = fmt.Sprintf("resetbranchvrfy%d", rand.Int64N(1_000_000))
+	mainDB := env.Client.Database(brDB)
+	require.NoError(t, mainDB.Drop(ctx))
+
+	// main: one committed document (M1).
+	_, err := mainDB.Collection("tasks").InsertOne(ctx, bson.D{
+		{Key: "_id", Value: int32(1)}, {Key: "v", Value: int32(1)},
+	})
+	require.NoError(t, err)
+	hashM1 = dumboDBCommit(t, env, brDB, "main-base", "alice <alice@acme.com>")
+
+	// Create a feature branch from main, then add two commits on it (F1, F2).
+	bsBranchCreate(t, env, brDB, "main", "feature")
+	featDB := env.Client.Database(brDB + "@feature")
+
+	_, err = featDB.Collection("tasks").InsertOne(ctx, bson.D{
+		{Key: "_id", Value: int32(2)}, {Key: "v", Value: int32(2)},
+	})
+	require.NoError(t, err)
+	hashF1 = dumboDBCommit(t, env, brDB+"@feature", "feature-one", "carol <carol@acme.com>")
+
+	_, err = featDB.Collection("tasks").InsertOne(ctx, bson.D{
+		{Key: "_id", Value: int32(3)}, {Key: "v", Value: int32(3)},
+	})
+	require.NoError(t, err)
+	hashF2 = dumboDBCommit(t, env, brDB+"@feature", "feature-two", "carol <carol@acme.com>")
+	require.NotEqual(t, hashF1, hashF2, "feature must have two distinct commits")
+
+	return brDB, hashM1, hashF1, hashF2
 }
 
 func TestResetVerify(t *testing.T) {
@@ -178,7 +234,7 @@ func TestResetVerify(t *testing.T) {
 			{Key: "v", Value: int32(2)},
 		})
 		require.NoError(t, err)
-		dumboDBCommit(t, env, dbName, "re-add-two", "alice <alice@acme.com>")
+		dumboDBCommit(t, env, dbName, "re-add-two", "bob <bob@widgets.io>")
 
 		// Soft reset to hashC1  -- "undoes" the re-add-two commit.
 		var raw bson.M
@@ -231,6 +287,20 @@ func TestResetVerify(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// Pre-check (mirrors the doc): the uncommitted _id:5 must show as a staged
+		// change before we discard it, so an empty diff after reset is meaningful.
+		var preDiffRaw bson.M
+		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
+			{Key: "doltDiff", Value: int32(1)},
+		}).Decode(&preDiffRaw))
+		preCD := findCollDiff(decodeDiffResult(t, preDiffRaw), "tasks")
+		require.NotNil(t, preCD, "expected a 'tasks' diff for the uncommitted _id:5 insert")
+		preAdded := make(map[any]bool)
+		for _, a := range preCD.Added {
+			preAdded[a["_id"]] = true
+		}
+		assert.True(t, preAdded[int32(5)], "_id:5 must show as added before the reset")
+
 		// Hard reset with no `to`  -- should default to HEAD.
 		var raw bson.M
 		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
@@ -256,6 +326,29 @@ func TestResetVerify(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n,
 			"after hard reset to HEAD: exactly 1 document must be visible")
+
+		// Bare soft reset {doltReset:1} (no `to`, no `hard`) defaults to HEAD and is
+		// a no-op in effect: HEAD unchanged, working tree unchanged. It must still
+		// succeed and return the current HEAD hash (doc Scenario 4 note + Quick Ref).
+		var softRaw bson.M
+		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
+			{Key: "doltReset", Value: int32(1)},
+		}).Decode(&softRaw))
+		assert.Equal(t, headHash, softRaw["commitId"], "bare soft reset must return current HEAD hash")
+		assert.EqualValues(t, 1, softRaw["ok"], "bare soft reset must report ok:1")
+
+		// The no-op soft reset must not perturb the working set: diff still empty,
+		// still only _id:1 visible.
+		var softDiffRaw bson.M
+		require.NoError(t, env.Client.Database(dbName).RunCommand(ctx, bson.D{
+			{Key: "doltDiff", Value: int32(1)},
+		}).Decode(&softDiffRaw))
+		assert.Empty(t, decodeDiffResult(t, softDiffRaw).Collections,
+			"after bare soft reset to HEAD: diff must remain empty")
+		n, err = items.CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n,
+			"after bare soft reset to HEAD: exactly 1 document must be visible")
 	})
 
 	// -------------------------------------------------------------------------
@@ -320,5 +413,83 @@ func TestResetVerify(t *testing.T) {
 			{Key: "to", Value: "main"},
 		}).Decode(&raw))
 		assert.Equal(t, hashC5, raw["commitId"], "to:'main' must return main's HEAD")
+	})
+
+	// -------------------------------------------------------------------------
+	// Scenario 6: Soft reset on a non-main branch  -- only the target branch moves
+	// -------------------------------------------------------------------------
+	t.Run("Scenario6_SoftResetOnNonMainBranch", func(t *testing.T) {
+		brDB, hashM1, hashF1, _ := resetBranchVerifySetup(t, env)
+		featDB := env.Client.Database(brDB + "@feature")
+
+		// Soft-reset feature back to F1 (no `hard`): feature HEAD moves to F1 but
+		// the working tree is preserved, so _id:3 becomes an uncommitted addition.
+		var raw bson.M
+		require.NoError(t, featDB.RunCommand(ctx, bson.D{
+			{Key: "doltReset", Value: int32(1)},
+			{Key: "to", Value: hashF1},
+		}).Decode(&raw))
+		assert.Equal(t, hashF1, raw["commitId"], "soft reset on feature must resolve to F1")
+		assert.EqualValues(t, 1, raw["ok"])
+
+		// feature: HEAD moved to F1, working tree preserved (still _id:1,2,3).
+		assert.Equal(t, hashF1, branchHead(t, env, brDB+"@feature"),
+			"feature HEAD must be F1 after soft reset on feature")
+		fn, err := featDB.Collection("tasks").CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), fn,
+			"soft reset preserves the feature working tree (_id:1,2,3)")
+
+		// feature diff: HEAD=F1 vs working set shows _id:3 as the only addition.
+		var diffRaw bson.M
+		require.NoError(t, featDB.RunCommand(ctx, bson.D{
+			{Key: "doltDiff", Value: int32(1)},
+		}).Decode(&diffRaw))
+		cd := findCollDiff(decodeDiffResult(t, diffRaw), "tasks")
+		require.NotNil(t, cd, "expected a 'tasks' diff on feature after soft reset")
+		require.Len(t, cd.Added, 1, "exactly _id:3 should be uncommitted after soft reset to F1")
+		assert.Equal(t, int32(3), cd.Added[0]["_id"], "the uncommitted addition must be _id:3")
+
+		// main must be completely untouched: HEAD=M1, working set = {_id:1}.
+		assert.Equal(t, hashM1, branchHead(t, env, brDB),
+			"main HEAD must be unchanged by a soft reset on feature")
+		mn, err := env.Client.Database(brDB).Collection("tasks").CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), mn,
+			"main working set must be untouched by a soft reset on feature")
+	})
+
+	// -------------------------------------------------------------------------
+	// Scenario 7: Hard reset on a non-main branch  -- only the target branch moves
+	// -------------------------------------------------------------------------
+	t.Run("Scenario7_HardResetOnNonMainBranch", func(t *testing.T) {
+		brDB, hashM1, hashF1, _ := resetBranchVerifySetup(t, env)
+		featDB := env.Client.Database(brDB + "@feature")
+
+		// Hard-reset the feature branch back to F1.
+		var raw bson.M
+		require.NoError(t, featDB.RunCommand(ctx, bson.D{
+			{Key: "doltReset", Value: int32(1)},
+			{Key: "to", Value: hashF1},
+			{Key: "hard", Value: true},
+		}).Decode(&raw))
+		assert.Equal(t, hashF1, raw["commitId"], "hard reset on feature must resolve to F1")
+		assert.EqualValues(t, 1, raw["ok"])
+
+		// feature: HEAD=F1 and working set reset to {_id:1,_id:2}.
+		assert.Equal(t, hashF1, branchHead(t, env, brDB+"@feature"),
+			"feature HEAD must be F1 after hard reset on feature")
+		fn, err := featDB.Collection("tasks").CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), fn,
+			"feature working set must show 2 docs (_id:1,2) after hard reset to F1")
+
+		// main must be completely untouched: HEAD=M1, working set = {_id:1}.
+		assert.Equal(t, hashM1, branchHead(t, env, brDB),
+			"main HEAD must be unchanged by a hard reset on feature")
+		mn, err := env.Client.Database(brDB).Collection("tasks").CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), mn,
+			"main working set must be untouched (only _id:1) by a hard reset on feature")
 	})
 }

--- a/tests/verify/reset_test.go
+++ b/tests/verify/reset_test.go
@@ -508,4 +508,92 @@ func TestResetVerify(t *testing.T) {
 		assert.Equal(t, int64(1), mn,
 			"main working set must be untouched (only _id:1) by a hard reset on feature")
 	})
+
+	// -------------------------------------------------------------------------
+	// Scenario 8: Hard reset to a commit on another branch  -- content follows target
+	// -------------------------------------------------------------------------
+	t.Run("Scenario8_HardResetToCommitOnOtherBranch", func(t *testing.T) {
+		brDB, _, hashF1, hashF2 := resetBranchVerifySetup(t, env)
+		mainDB := env.Client.Database(brDB)
+		tasks := mainDB.Collection("tasks")
+
+		// On main, hard-reset to F1  -- a commit that lives on the feature branch.
+		var raw bson.M
+		require.NoError(t, mainDB.RunCommand(ctx, bson.D{
+			{Key: "doltReset", Value: int32(1)},
+			{Key: "to", Value: hashF1},
+			{Key: "hard", Value: true},
+		}).Decode(&raw))
+		assert.Equal(t, hashF1, raw["commitId"], "reset must resolve to the feature commit F1")
+		assert.EqualValues(t, 1, raw["ok"])
+
+		// main HEAD moved to F1 and its content now follows the target: {_id:1,_id:2},
+		// including _id:2 which was only ever committed on the feature branch.
+		assert.Equal(t, hashF1, branchHead(t, env, brDB), "main HEAD must be F1 after hard reset")
+		mn, err := tasks.CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), mn, "main content must follow F1 (2 docs: _id:1,2)")
+		got2, err := tasks.CountDocuments(ctx, bson.D{{Key: "_id", Value: int32(2)}})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), got2, "_id:2 (feature content) must now be present on main")
+		got3, err := tasks.CountDocuments(ctx, bson.D{{Key: "_id", Value: int32(3)}})
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), got3, "_id:3 (only on F2) must not be present after reset to F1")
+
+		// Working set matches the new HEAD  -- diff is empty.
+		var diffRaw bson.M
+		require.NoError(t, mainDB.RunCommand(ctx, bson.D{{Key: "doltDiff", Value: int32(1)}}).Decode(&diffRaw))
+		assert.Empty(t, decodeDiffResult(t, diffRaw).Collections,
+			"after hard reset the working set must match HEAD (empty diff)")
+
+		// The feature branch is untouched: HEAD still F2, still 3 docs.
+		assert.Equal(t, hashF2, branchHead(t, env, brDB+"@feature"),
+			"feature HEAD must be unchanged by a reset on main")
+		fn, err := env.Client.Database(brDB+"@feature").Collection("tasks").CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), fn, "feature content must be unchanged (3 docs)")
+	})
+
+	// -------------------------------------------------------------------------
+	// Scenario 9: Soft reset to a commit on another branch  -- diff reflects the gap
+	// -------------------------------------------------------------------------
+	t.Run("Scenario9_SoftResetToCommitOnOtherBranch", func(t *testing.T) {
+		brDB, _, hashF1, hashF2 := resetBranchVerifySetup(t, env)
+		mainDB := env.Client.Database(brDB)
+		tasks := mainDB.Collection("tasks")
+
+		// On main, soft-reset to F1 (a feature-branch commit). HEAD moves to F1 but
+		// main's working tree (still M1 = {_id:1}) is preserved.
+		var raw bson.M
+		require.NoError(t, mainDB.RunCommand(ctx, bson.D{
+			{Key: "doltReset", Value: int32(1)},
+			{Key: "to", Value: hashF1},
+		}).Decode(&raw))
+		assert.Equal(t, hashF1, raw["commitId"], "soft reset must resolve to the feature commit F1")
+		assert.EqualValues(t, 1, raw["ok"])
+		assert.Equal(t, hashF1, branchHead(t, env, brDB), "main HEAD must be F1 after soft reset")
+
+		// Working tree preserved at M1: only _id:1 is visible.
+		mn, err := tasks.CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), mn, "soft reset preserves main's working tree (_id:1 only)")
+
+		// The diff makes sense: the new HEAD F1 has {_id:1,_id:2} but the working
+		// tree has only {_id:1}, so _id:2 shows as removed relative to the new HEAD.
+		var diffRaw bson.M
+		require.NoError(t, mainDB.RunCommand(ctx, bson.D{{Key: "doltDiff", Value: int32(1)}}).Decode(&diffRaw))
+		cd := findCollDiff(decodeDiffResult(t, diffRaw), "tasks")
+		require.NotNil(t, cd, "expected a 'tasks' diff after soft reset across branches")
+		require.Len(t, cd.Removed, 1, "exactly _id:2 must be missing from the working tree vs the new HEAD")
+		assert.Equal(t, int32(2), cd.Removed[0]["_id"], "the removed doc must be _id:2")
+		assert.Empty(t, cd.Added, "no docs should be added")
+		assert.Empty(t, cd.Modified, "no docs should be modified")
+
+		// The feature branch is untouched: HEAD still F2, still 3 docs.
+		assert.Equal(t, hashF2, branchHead(t, env, brDB+"@feature"),
+			"feature HEAD must be unchanged by a reset on main")
+		fn, err := env.Client.Database(brDB+"@feature").Collection("tasks").CountDocuments(ctx, bson.D{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), fn, "feature content must be unchanged (3 docs)")
+	})
 }


### PR DESCRIPTION
Previously `main` branch was hardcoded in the reset command.