### PR TITLE
recover when lsid shows up after session was reaped

### DIFF
--- a/cmd/dumbodb/main.go
+++ b/cmd/dumbodb/main.go
@@ -59,7 +59,7 @@ func handleVersionFlag() {
 				fmt.Fprintln(os.Stderr, "--version/-v cannot be combined with other arguments")
 				os.Exit(2)
 			}
-			fmt.Printf("dumbodb %s (commit %s)\n", version.Version, version.GitVersion)
+			fmt.Printf("dumbodb %s\n", version.Get().Version)
 			os.Exit(0)
 		}
 	}

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -608,7 +608,9 @@ func (c *conn) dispatchThroughSession(connCtx context.Context, msg *wire.OpMsg, 
 	lsid := ci.EnsureLSID()
 
 	shadow, cachedLsid := ci.CachedShadow()
-	if shadow == nil || cachedLsid != lsid {
+	staleReap := shadow != nil && cachedLsid == lsid && !shadow.Active() &&
+		shadow.Purged() && !c.h.SessionIsolation() && !ci.InTransaction()
+	if shadow == nil || cachedLsid != lsid || staleReap {
 		// Release the prior lsid (synthetic-to-real upgrade, or pooled
 		// implicit sessions rotating between frames) before opening the
 		// new one.
@@ -622,11 +624,6 @@ func (c *conn) dispatchThroughSession(connCtx context.Context, msg *wire.OpMsg, 
 		ci.SetCachedShadow(lsid, s)
 		shadow = s
 	}
-	// A re-Connect here would ping-pong supersedes between this
-	// connection and the one that took over; surface the terminal
-	// error instead. Distinguish supersede (another connection took
-	// over) from purge (Sweep / End reaped the session) so the wire
-	// code matches MongoDB's semantics.
 	if !shadow.Active() {
 		return nil, shadowGoneError(shadow)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,14 +20,9 @@ import (
 	"github.com/dolthub/dumbodb/internal/util/must"
 )
 
-const (
-	// Version is the DumboDB build version.
-	Version = "v0.1.0"
-
-	// MongoDBVersion is the MongoDB version DumboDB advertises to clients
-	// that gate behavior on major.minor.
-	MongoDBVersion = "8.0.20"
-)
+// MongoDBVersion is the MongoDB version DumboDB advertises to clients
+// that gate behavior on major.minor.
+const MongoDBVersion = "8.0.20"
 
 // GitVersion is the source git commit hash. Set at build time via:
 //
@@ -54,7 +49,7 @@ type Info struct {
 }
 
 var info = &Info{
-	Version:             Version,
+	Version:             GitVersion,
 	Commit:              GitVersion,
 	Branch:              "unknown",
 	Dirty:               false,

--- a/tests/session_idle_reuse_test.go
+++ b/tests/session_idle_reuse_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// TestSession_IdleReap_ReuseRecovers pins the fix for a wedge where a client
+// reusing a session after the idle sweep reaped it got a permanent code-251
+// error (as mongo-express did after sitting idle). A plain command must recover
+// on a fresh session, matching MongoDB, which recreates reaped idle sessions.
+func TestSession_IdleReap_ReuseRecovers(t *testing.T) {
+	env := startDumboDB(t, "--session-timeout", "1s", "--session-sweep-period", "1s")
+	ctx := context.Background()
+	coll := env.Collection(t)
+
+	sess, err := env.Client.StartSession()
+	require.NoError(t, err)
+	defer sess.EndSession(ctx)
+	sc := mongo.NewSessionContext(ctx, sess)
+
+	_, err = coll.InsertOne(sc, bson.D{{Key: "_id", Value: "before-reap"}})
+	require.NoError(t, err, "first write establishes the session")
+
+	time.Sleep(3 * time.Second)
+
+	_, err = coll.InsertOne(sc, bson.D{{Key: "_id", Value: "after-reap"}})
+	require.NoError(t, err, "reusing an idle-reaped session must recover, not fail with 251")
+
+	_, err = coll.InsertOne(sc, bson.D{{Key: "_id", Value: "after-reap-2"}})
+	require.NoError(t, err, "recovery must be permanent, not one-shot")
+
+	n, err := coll.CountDocuments(ctx, bson.D{})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, n)
+}


### PR DESCRIPTION
Long running servers which go silent for 30 min then come back were encountering errors like:

`Transaction has been aborted because the session was idle past the configured timeout.`

This change recreated the session as needed to keep clients happy.