### PR TITLE
Rename dumboUndrop wire field to_database to toDatabase

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1390,7 +1390,7 @@ Default mode walks new-gen chunks only -- chunks already promoted to oldgen arch
 
 Restores a soft-deleted database, or lists the databases available to undrop.
 
-When a database is dropped with `dropDatabase`, it is not deleted: its directory is moved into the preserved-drops directory and can be restored. `dumboUndrop` restores a **copy** of a drop -- the drop itself stays preserved and listed until the 30-day GC purges it, so one drop can be restored repeatedly (e.g. under several names via `to_database`). Repeat drops of the same name are all retained, distinguished by a `dropId`. Pass `to_database` to restore under a different name.
+When a database is dropped with `dropDatabase`, it is not deleted: its directory is moved into the preserved-drops directory and can be restored. `dumboUndrop` restores a **copy** of a drop -- the drop itself stays preserved and listed until the 30-day GC purges it, so one drop can be restored repeatedly (e.g. under several names via `toDatabase`). Repeat drops of the same name are all retained, distinguished by a `dropId`. Pass `toDatabase` to restore under a different name.
 
 **Alias:** `doltUndrop`
 
@@ -1402,8 +1402,8 @@ When a database is dropped with `dropDatabase`, it is not deleted: its directory
 |-----------|------|----------|---------|-------------|
 | `name` | string | no | `""` | Database to restore. Omit to list databases available to undrop. Must be a root database name (no `@branch`/`@revision`). |
 | `dropId` | string | no | `""` | Selects a specific drop when `name` has more than one preserved copy. Omit to restore the most recent drop. Use the `dropId` from the list response. |
-| `to_database` | string | no | `""` | Restore the drop under this name instead of its original. Requires `name`; must be a root database name (no `@branch`/`@revision`) and not a system database (`admin`, `config`, `local`). |
-| `purgeMatching` | object | no |  -- | Purge mode: permanently delete preserved drops matching the filter (see below). Mutually exclusive with `name`/`dropId`/`to_database`. |
+| `toDatabase` | string | no | `""` | Restore the drop under this name instead of its original. Requires `name`; must be a root database name (no `@branch`/`@revision`) and not a system database (`admin`, `config`, `local`). |
+| `purgeMatching` | object | no |  -- | Purge mode: permanently delete preserved drops matching the filter (see below). Mutually exclusive with `name`/`dropId`/`toDatabase`. |
 
 ### Purge mode (`purgeMatching`)
 
@@ -1431,7 +1431,7 @@ A drop is purged only if it satisfies **every** field that is set (AND). `name` 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `undropped` | string | Restored database name (the `to_database` name when one is given) |
+| `undropped` | string | Restored database name (the `toDatabase` name when one is given) |
 | `dropId` | string | Id of the drop that was restored |
 | `ok` | number | `1` on success |
 
@@ -1454,7 +1454,7 @@ admin.runCommand({ dumboUndrop: 1, name: "orders" })
 // { undropped: "orders", dropId: "1775505756999075683", ok: 1 }
 
 // Restore it under a different name
-admin.runCommand({ dumboUndrop: 1, name: "orders", to_database: "orders_recovered" })
+admin.runCommand({ dumboUndrop: 1, name: "orders", toDatabase: "orders_recovered" })
 // { undropped: "orders_recovered", dropId: "1775505756999075683", ok: 1 }
 
 // Purge every drop of "orders" older than a cutoff, before the 30-day GC
@@ -1471,12 +1471,12 @@ admin.runCommand({ dumboUndrop: 1, purgeMatching: { name: "orders", droppedBefor
 | `dropId` does not match any drop | `OperationFailed: undrop: database "<name>" has no dropped copy with dropId "<id>"` |
 | A live database with the target name already exists | `OperationFailed: undrop: a live database named "<name>" already exists` |
 | `name` is revision-qualified (`db@rev`) | `OperationFailed: dumboUndrop: name must be a root database, ...` |
-| `to_database` given without `name` | `OperationFailed: dumboUndrop: to_database requires name` |
-| `to_database` is revision-qualified (`db@rev`) | `OperationFailed: dumboUndrop: to_database must be a root database, ...` |
+| `toDatabase` given without `name` | `OperationFailed: dumboUndrop: toDatabase requires name` |
+| `toDatabase` is revision-qualified (`db@rev`) | `OperationFailed: dumboUndrop: toDatabase must be a root database, ...` |
 | Target is a system database (`admin`, `config`, `local`) | `OperationFailed: dumboUndrop: cannot restore to system database <name>` |
 | `purgeMatching` without `name` | `OperationFailed: dumboUndrop: purgeMatching requires name` |
 | `purgeMatching` has an unknown field | `OperationFailed: dumboUndrop: purgeMatching has unknown field <field> (allowed: name, dropId, droppedBefore)` |
-| `purgeMatching` combined with `name`/`dropId`/`to_database` | `OperationFailed: dumboUndrop: purgeMatching cannot be combined with <field>` |
+| `purgeMatching` combined with `name`/`dropId`/`toDatabase` | `OperationFailed: dumboUndrop: purgeMatching cannot be combined with <field>` |
 
 ### Notes
 

--- a/docs/verify/undrop.md
+++ b/docs/verify/undrop.md
@@ -11,7 +11,7 @@ setup.
 preserved-drops directory at `<dataDir>/.dumbodb_dropped_databases/<name>/<dropId>/`, where
 `dropId` is the nanosecond timestamp of the drop. `dumboUndrop` restores a
 **copy**: the drop stays preserved and listed, so it can be restored again (for
-example under several names via `to_database`). Repeat drops of the same name are
+example under several names via `toDatabase`). Repeat drops of the same name are
 all retained, distinguished by `dropId`. A background job runs hourly and
 permanently deletes any preserved drop more than 30 days old, logging an INFO
 line per deletion.
@@ -27,7 +27,7 @@ because it operates across the whole instance rather than on a single database.
 |-----------|--------|----------|---------|----------------------------------------------------------------------------------------------|
 | `name`    | string | no       |  --      | Database to restore. Omit to list databases available to undrop. Must be a root name (no `@`). |
 | `dropId`  | string | no       |  --      | Selects one drop when `name` has more than one preserved copy. Use the `dropId` from the list. |
-| `to_database` | string | no   |  --      | Restore the drop under this name instead of its original. Requires `name`; must be a root name (no `@`) and not a system database (`admin`, `config`, `local`). |
+| `toDatabase` | string | no   |  --      | Restore the drop under this name instead of its original. Requires `name`; must be a root name (no `@`) and not a system database (`admin`, `config`, `local`). |
 | `purgeMatching` | object | no |  --      | Purge mode: permanently delete drops matching `{name (required), dropId, droppedBefore}` (AND). Mutually exclusive with the restore parameters. |
 
 ## Prerequisites
@@ -258,9 +258,9 @@ Key checks:
 
 ---
 
-## Scenario 4c: Restore under different names (to_database), repeatedly
+## Scenario 4c: Restore under different names (toDatabase), repeatedly
 
-Pass `to_database` to restore a drop under a new name. Because restore copies,
+Pass `toDatabase` to restore a drop under a new name. Because restore copies,
 one drop can seed several independent live databases.
 
 ```js
@@ -270,7 +270,7 @@ s.runCommand({ doltCommit: 1, message: "s1", author: "a <a@a>" })
 s.dropDatabase()
 
 // First copy
-db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "srcdb", to_database: "destdb" })
+db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "srcdb", toDatabase: "destdb" })
 // Expected: { undropped: "destdb", dropId: <id>, ok: 1 }
 db.getSiblingDB("destdb").items.findOne({ _id: 1 }).tag
 // Expected: "orig"
@@ -280,7 +280,7 @@ db.getSiblingDB("admin").runCommand({ dumboUndrop: 1 }).dropped.map(d => d.name)
 // Expected: true
 
 // Second copy from the same drop, under another name
-db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "srcdb", to_database: "destdb2" })
+db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "srcdb", toDatabase: "destdb2" })
 db.getSiblingDB("destdb2").items.findOne({ _id: 1 }).tag
 // Expected: "orig" -- an independent copy
 
@@ -339,16 +339,16 @@ db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "ledger" })
 db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "ledger@main" })
 // Expected: ok: 0; errmsg says name must be a root database
 
-// to_database without name is an error
-db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, to_database: "somewhere" })
-// Expected: ok: 0; errmsg contains "to_database requires name"
+// toDatabase without name is an error
+db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, toDatabase: "somewhere" })
+// Expected: ok: 0; errmsg contains "toDatabase requires name"
 
-// to_database must be a root name
-db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "ledger", to_database: "dest@main" })
-// Expected: ok: 0; errmsg says to_database must be a root database
+// toDatabase must be a root name
+db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "ledger", toDatabase: "dest@main" })
+// Expected: ok: 0; errmsg says toDatabase must be a root database
 
 // cannot restore onto a reserved system database
-db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "ledger", to_database: "config" })
+db.getSiblingDB("admin").runCommand({ dumboUndrop: 1, name: "ledger", toDatabase: "config" })
 // Expected: ok: 0; errmsg says cannot restore to system database
 ```
 
@@ -504,13 +504,13 @@ restore succeeds.
 | `db.getSiblingDB("admin").runCommand({ dumboUndrop: 1 })`           | List databases available to undrop                |
 | `... runCommand({ dumboUndrop: 1, name: "x" })`                     | Restore `x` (the most recent drop)                |
 | `... runCommand({ dumboUndrop: 1, name: "x", dropId: "<id>" })`     | Restore a specific drop of `x`                     |
-| `... runCommand({ dumboUndrop: 1, name: "x", to_database: "y" })`   | Restore `x`'s drop under the name `y`             |
+| `... runCommand({ dumboUndrop: 1, name: "x", toDatabase: "y" })`   | Restore `x`'s drop under the name `y`             |
 | `... runCommand({ dumboUndrop: 1, purgeMatching: { name: "x" } })`  | Permanently delete drops matching the filter      |
 
 - `dropDatabase` only works on a root database name; system databases (`admin`, `config`, `local`) cannot be dropped.
 - `dumboUndrop` must be run against `admin`.
 - Repeat drops of one name are all retained; `dropId` selects among them.
-- `to_database` restores under a new name; it requires `name`.
+- `toDatabase` restores under a new name; it requires `name`.
 - Undrop restores the complete commit history, not just the latest data.
 - Undrop copies the drop; it stays listed and can be restored again until purged. Restoring onto a live database name is rejected.
 - `purgeMatching` deletes drops early: `name` is required, optionally narrowed by `dropId` and/or `droppedBefore` (AND).

--- a/internal/handler/msg_dumbodb_undrop.go
+++ b/internal/handler/msg_dumbodb_undrop.go
@@ -79,7 +79,7 @@ func (h *Handler) MsgDumboDBUndrop(connCtx context.Context, msg *wire.OpMsg) (*w
 		return nil, err
 	}
 
-	toDatabase, err := common.GetOptionalParam[string](document, "to_database", "")
+	toDatabase, err := common.GetOptionalParam[string](document, "toDatabase", "")
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (h *Handler) MsgDumboDBUndrop(connCtx context.Context, msg *wire.OpMsg) (*w
 	if toDatabase != "" && name == "" {
 		return nil, handlererrors.NewCommandErrorMsg(
 			handlererrors.ErrOperationFailed,
-			"dumboUndrop: to_database requires name",
+			"dumboUndrop: toDatabase requires name",
 		)
 	}
 
@@ -116,7 +116,7 @@ func (h *Handler) MsgDumboDBUndrop(connCtx context.Context, msg *wire.OpMsg) (*w
 		return nil, err
 	}
 
-	if err = rejectRevisionQualifiedName(toDatabase, "to_database"); err != nil {
+	if err = rejectRevisionQualifiedName(toDatabase, "toDatabase"); err != nil {
 		return nil, err
 	}
 
@@ -159,7 +159,7 @@ var purgeMatchingDroppedDatabaseFields = map[string]struct{}{
 // purgeMatchingDroppedDatabases handles `dumboUndrop` with a purgeMatching filter:
 // it permanently removes preserved drops matching {name, dropId, droppedBefore}.
 func (h *Handler) purgeMatchingDroppedDatabases(connCtx context.Context, vb backends.VersioningBackend, document, pm *types.Document) (*wire.OpMsg, error) {
-	for _, k := range []string{"name", "dropId", "to_database"} {
+	for _, k := range []string{"name", "dropId", "toDatabase"} {
 		if document.Has(k) {
 			return nil, handlererrors.NewCommandErrorMsg(
 				handlererrors.ErrOperationFailed,

--- a/tests/verify/undrop_test.go
+++ b/tests/verify/undrop_test.go
@@ -196,7 +196,7 @@ func TestUndropVerify(t *testing.T) {
 		undropDropDB(t, env, "srcdb")
 
 		res, err := undropAdmin(t, env, bson.D{
-			{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "srcdb"}, {Key: "to_database", Value: "destdb"},
+			{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "srcdb"}, {Key: "toDatabase", Value: "destdb"},
 		})
 		require.NoError(t, err)
 		assert.EqualValues(t, "destdb", res["undropped"], "restored under the alternate name")
@@ -208,10 +208,10 @@ func TestUndropVerify(t *testing.T) {
 
 		list, err := undropAdmin(t, env, bson.D{{Key: "dumboUndrop", Value: 1}})
 		require.NoError(t, err)
-		assert.Contains(t, droppedNames(list), "srcdb", "drop remains after a to_database restore")
+		assert.Contains(t, droppedNames(list), "srcdb", "drop remains after a toDatabase restore")
 
 		_, err = undropAdmin(t, env, bson.D{
-			{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "srcdb"}, {Key: "to_database", Value: "destdb2"},
+			{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "srcdb"}, {Key: "toDatabase", Value: "destdb2"},
 		})
 		require.NoError(t, err)
 		require.NoError(t, env.Client.Database("destdb2").Collection("items").
@@ -261,19 +261,19 @@ func TestUndropVerify(t *testing.T) {
 		_, err = undropAdmin(t, env, bson.D{{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "ledger@main"}})
 		require.Error(t, err)
 
-		_, err = undropAdmin(t, env, bson.D{{Key: "dumboUndrop", Value: 1}, {Key: "to_database", Value: "somewhere"}})
+		_, err = undropAdmin(t, env, bson.D{{Key: "dumboUndrop", Value: 1}, {Key: "toDatabase", Value: "somewhere"}})
 		require.Error(t, err)
-		assert.Contains(t, strings.ToLower(err.Error()), "to_database requires name")
+		assert.Contains(t, strings.ToLower(err.Error()), "todatabase requires name")
 
 		_, err = undropAdmin(t, env, bson.D{
-			{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "ledger"}, {Key: "to_database", Value: "dest@main"},
+			{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "ledger"}, {Key: "toDatabase", Value: "dest@main"},
 		})
 		require.Error(t, err)
-		assert.Contains(t, strings.ToLower(err.Error()), "to_database must be a root database")
+		assert.Contains(t, strings.ToLower(err.Error()), "todatabase must be a root database")
 
 		for _, sys := range []string{"config", "local"} {
 			_, err = undropAdmin(t, env, bson.D{
-				{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "ledger"}, {Key: "to_database", Value: sys},
+				{Key: "dumboUndrop", Value: 1}, {Key: "name", Value: "ledger"}, {Key: "toDatabase", Value: sys},
 			})
 			require.Error(t, err, "undrop to %q must be rejected", sys)
 			assert.Contains(t, strings.ToLower(err.Error()), "system database")


### PR DESCRIPTION
Bring the field in line with the command's other camelCase fields (dropId, purgeMatching, droppedBefore). Updates the handler param lookup and error messages, the verify tests, and the COMMANDS.md and verify/undrop.md docs.