### PR TITLE
soak: report a breakdown of workload errors by type

### DIFF
--- a/cmd/soak/errorstats.go
+++ b/cmd/soak/errorstats.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// errorStats tallies workload errors by a normalized signature so the
+// report can say what the errors were, not just how many. Each bucket
+// keeps one example message verbatim.
+type errorStats struct {
+	mu     sync.Mutex
+	total  int64
+	counts map[string]int64
+	sample map[string]string
+}
+
+func newErrorStats() *errorStats {
+	return &errorStats{counts: map[string]int64{}, sample: map[string]string{}}
+}
+
+func (e *errorStats) record(op string, err error) {
+	if err == nil {
+		return
+	}
+	key := op + " / " + classifyError(err)
+	e.mu.Lock()
+	e.total++
+	e.counts[key]++
+	if _, ok := e.sample[key]; !ok {
+		e.sample[key] = truncate(strings.Join(strings.Fields(err.Error()), " "), 200)
+	}
+	e.mu.Unlock()
+}
+
+func (e *errorStats) count() int64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.total
+}
+
+type errorTally struct {
+	Key    string
+	Count  int64
+	Sample string
+}
+
+func (e *errorStats) snapshot() []errorTally {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]errorTally, 0, len(e.counts))
+	for k, c := range e.counts {
+		out = append(out, errorTally{Key: k, Count: c, Sample: e.sample[k]})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+// classifyError reduces an error to a stable bucket key. Server errors
+// key on their name/code, context and network failures on their kind,
+// and anything else on a digit-collapsed message so per-id and per-ns
+// variation does not fragment the buckets.
+func classifyError(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "context canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context deadline exceeded"
+	}
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) {
+		return serverErrorKey(cmdErr.Name, cmdErr.Code)
+	}
+	var writeErr mongo.WriteException
+	if errors.As(err, &writeErr) {
+		if len(writeErr.WriteErrors) > 0 {
+			we := writeErr.WriteErrors[0]
+			return serverErrorKey("", int32(we.Code))
+		}
+		if writeErr.WriteConcernError != nil {
+			return serverErrorKey("", int32(writeErr.WriteConcernError.Code))
+		}
+	}
+	if mongo.IsNetworkError(err) {
+		return "network error"
+	}
+	return collapseDigits(strings.Join(strings.Fields(err.Error()), " "))
+}
+
+func serverErrorKey(name string, code int32) string {
+	if name != "" {
+		return fmt.Sprintf("%s (code %d)", name, code)
+	}
+	return fmt.Sprintf("code %d", code)
+}
+
+// collapseDigits replaces runs of digits with '#' so ids, timestamps
+// and ns suffixes collapse into a single bucket, then caps the length.
+func collapseDigits(s string) string {
+	var b strings.Builder
+	prevDigit := false
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			if !prevDigit {
+				b.WriteByte('#')
+			}
+			prevDigit = true
+			continue
+		}
+		prevDigit = false
+		b.WriteRune(r)
+	}
+	return truncate(b.String(), 120)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -198,7 +198,7 @@ func main() {
 		// the crash report and carries the server-log tail.
 		text, htmlBody := summaryReport(hostname, buildVer, pid, addr, startedAt, time.Now(),
 			sampleCount, alertCount, firstSample, lastSample, allSamples,
-			wl.cycleCount(), wl.errCount(), serverExit, serverCrashTail)
+			wl.cycleCount(), wl.errCount(), wl.errorBreakdown(), serverExit, serverCrashTail)
 		subj := fmt.Sprintf("dumbodb soak: %d alert(s)", alertCount)
 		if alertCount == 0 {
 			subj = "dumbodb soak: clean"
@@ -338,7 +338,7 @@ func alertReport(host, buildVer string, pid int, addr string, a alert, recent []
 
 // summaryReport renders the end-of-run summary email as both plain
 // text and HTML.
-func summaryReport(host, buildVer string, pid int, addr string, startedAt, endedAt time.Time, samples, alerts int, first, last procSample, allSamples []sample, cycles, errs int64, serverExit string, serverCrashTail []string) (text, htmlBody string) {
+func summaryReport(host, buildVer string, pid int, addr string, startedAt, endedAt time.Time, samples, alerts int, first, last procSample, allSamples []sample, cycles, errs int64, errorBreakdown []errorTally, serverExit string, serverCrashTail []string) (text, htmlBody string) {
 	title := fmt.Sprintf("dumbodb soak summary on %s", host)
 	stats := []string{
 		fmt.Sprintf("build: %s", buildVer),
@@ -349,6 +349,12 @@ func summaryReport(host, buildVer string, pid int, addr string, startedAt, ended
 		fmt.Sprintf("samples: %d collected", samples),
 		fmt.Sprintf("alerts: %d emitted during this run", alerts),
 		fmt.Sprintf("cycles: %d workload cycles, %d errors", cycles, errs),
+	}
+	if len(errorBreakdown) > 0 {
+		stats = append(stats, "errors by type (count / op / classification / example):")
+		for _, t := range errorBreakdown {
+			stats = append(stats, fmt.Sprintf("  %6d  %s  e.g. %s", t.Count, t.Key, t.Sample))
+		}
 	}
 	if serverExit != "" {
 		stats = append(stats, fmt.Sprintf("server: CRASHED - %s", serverExit))

--- a/cmd/soak/workers.go
+++ b/cmd/soak/workers.go
@@ -51,7 +51,7 @@ func (w *workload) runSessionWorker(ctx context.Context, uri string, delay time.
 			return
 		}
 		if err := connectPingDisconnect(ctx, uri); err != nil {
-			w.errors.Add(1)
+			w.errs.record("session", err)
 		}
 		w.cycles.Add(1)
 		if !sleep(ctx, delay) {
@@ -69,7 +69,7 @@ func (w *workload) runCRUDWorker(ctx context.Context, uri, collName string, work
 	defer w.wg.Done()
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -83,7 +83,7 @@ func (w *workload) runCRUDWorker(ctx context.Context, uri, collName string, work
 		op := r.Intn(4)
 		key := fmt.Sprintf("crud-w%d-k%05d", workerID, r.Intn(500))
 		if err := w.runOneCRUD(ctx, coll, op, key, r); err != nil {
-			w.errors.Add(1)
+			w.errs.record("crud", err)
 		}
 		w.cycles.Add(1)
 		if !sleep(ctx, opsInterval) {
@@ -127,7 +127,7 @@ func (w *workload) runBulkWorker(ctx context.Context, uri, collName string, work
 	defer w.wg.Done()
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -151,7 +151,7 @@ func (w *workload) runBulkWorker(ctx context.Context, uri, collName string, work
 		_, err := coll.InsertMany(cctx, docs, options.InsertMany().SetOrdered(false))
 		cancel()
 		if err != nil {
-			w.errors.Add(1)
+			w.errs.record("bulk-insert", err)
 		}
 		w.cycles.Add(1)
 		// Bulk inserts are heavier; back off proportionally.
@@ -168,7 +168,7 @@ func (w *workload) runAggWorker(ctx context.Context, uri, collName string, worke
 	defer w.wg.Done()
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -188,7 +188,7 @@ func (w *workload) runAggWorker(ctx context.Context, uri, collName string, worke
 			}
 			cur.Close(cctx)
 		} else {
-			w.errors.Add(1)
+			w.errs.record("agg", err)
 		}
 		cancel()
 		w.cycles.Add(1)
@@ -244,7 +244,7 @@ func (w *workload) runIndexedWorker(ctx context.Context, uri, collName string, w
 	defer w.wg.Done()
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -266,7 +266,7 @@ func (w *workload) runIndexedWorker(ctx context.Context, uri, collName string, w
 				Options: options.Index().SetName(idxName),
 			})
 			if err != nil {
-				w.errors.Add(1)
+				w.errs.record("index-create", err)
 			}
 		}
 		lo := r.Intn(900)
@@ -276,7 +276,7 @@ func (w *workload) runIndexedWorker(ctx context.Context, uri, collName string, w
 			}
 			cur.Close(cctx)
 		} else {
-			w.errors.Add(1)
+			w.errs.record("indexed-find", err)
 		}
 		cancel()
 		cycle++
@@ -295,7 +295,7 @@ func (w *workload) runVCSWorker(ctx context.Context, uri, collName string, worke
 	defer w.wg.Done()
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -314,13 +314,13 @@ func (w *workload) runVCSWorker(ctx context.Context, uri, collName string, worke
 			_, _ = mainColl.InsertOne(ctx, makeDoc(r, key, pickSize(r)))
 		}
 		if err := runCmd(ctx, mainDB, 30*time.Second, bson.D{{"dumboCommit", 1}, {"message", fmt.Sprintf("vcs-w%d main commit", workerID)}}); err != nil {
-			w.errors.Add(1)
+			w.errs.record("vcs-commit", err)
 		}
 
 		// Create + populate + commit on the feature branch.
 		branch := fmt.Sprintf("vcs-w%d-b%d", workerID, branchSeq.Add(1))
 		if err := runCmd(ctx, mainDB, 30*time.Second, bson.D{{"dumboBranch", 1}, {"branch", branch}}); err != nil {
-			w.errors.Add(1)
+			w.errs.record("vcs-branch", err)
 		}
 		branchDB := client.Database("soak@" + branch)
 		branchColl := branchDB.Collection(collName)
@@ -329,7 +329,7 @@ func (w *workload) runVCSWorker(ctx context.Context, uri, collName string, worke
 			_, _ = branchColl.InsertOne(ctx, makeDoc(r, key, pickSize(r)))
 		}
 		if err := runCmd(ctx, branchDB, 30*time.Second, bson.D{{"dumboCommit", 1}, {"message", "branch commit"}}); err != nil {
-			w.errors.Add(1)
+			w.errs.record("vcs-commit", err)
 		}
 
 		// Merge the branch back to main. Conflicts can arise when
@@ -341,7 +341,7 @@ func (w *workload) runVCSWorker(ctx context.Context, uri, collName string, worke
 			{"message", fmt.Sprintf("soak merge of %s", branch)},
 			{"author", "soak <soak@dumbodb>"},
 		}); err != nil {
-			w.errors.Add(1)
+			w.errs.record("vcs-merge", err)
 		}
 
 		w.cycles.Add(1)
@@ -367,7 +367,7 @@ func (w *workload) runTxnWorker(ctx context.Context, uri, collName string, worke
 	defer w.wg.Done()
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -380,7 +380,7 @@ func (w *workload) runTxnWorker(ctx context.Context, uri, collName string, worke
 		}
 		sess, err := client.StartSession()
 		if err != nil {
-			w.errors.Add(1)
+			w.errs.record("txn-begin", err)
 			if !sleep(ctx, opsInterval) {
 				return
 			}
@@ -400,7 +400,7 @@ func (w *workload) runTxnWorker(ctx context.Context, uri, collName string, worke
 		cancel()
 		sess.EndSession(context.Background())
 		if err != nil {
-			w.errors.Add(1)
+			w.errs.record("txn", err)
 		}
 		w.cycles.Add(1)
 		if !sleep(ctx, opsInterval*3) {
@@ -431,7 +431,7 @@ func (w *workload) runTrimWorker(ctx context.Context, uri, collName string, cap 
 	}
 	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
-		w.errors.Add(1)
+		w.errs.record("connect", err)
 		return
 	}
 	defer client.Disconnect(context.Background())
@@ -445,10 +445,10 @@ func (w *workload) runTrimWorker(ctx context.Context, uri, collName string, cap 
 		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		count, err := coll.EstimatedDocumentCount(cctx)
 		if err != nil {
-			w.errors.Add(1)
+			w.errs.record("trim-count", err)
 		} else if del := trimBudget(int(count), cap, lowWater, interval); del > 0 {
 			if err := deleteOldest(cctx, coll, del); err != nil {
-				w.errors.Add(1)
+				w.errs.record("trim-delete", err)
 			}
 		}
 		cancel()

--- a/cmd/soak/workload.go
+++ b/cmd/soak/workload.go
@@ -29,7 +29,7 @@ type workload struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	cycles atomic.Int64
-	errors atomic.Int64
+	errs   *errorStats
 }
 
 // workloadConfig is what main.go fills out from flags.
@@ -48,8 +48,9 @@ type workloadConfig struct {
 	TrimInterval   time.Duration
 }
 
-func (w *workload) cycleCount() int64 { return w.cycles.Load() }
-func (w *workload) errCount() int64   { return w.errors.Load() }
+func (w *workload) cycleCount() int64            { return w.cycles.Load() }
+func (w *workload) errCount() int64              { return w.errs.count() }
+func (w *workload) errorBreakdown() []errorTally { return w.errs.snapshot() }
 
 func (w *workload) stop() {
 	w.cancel()
@@ -61,7 +62,7 @@ func (w *workload) stop() {
 // workers.
 func startWorkload(parent context.Context, cfg workloadConfig) (*workload, error) {
 	ctx, cancel := context.WithCancel(parent)
-	w := &workload{cancel: cancel}
+	w := &workload{cancel: cancel, errs: newErrorStats()}
 
 	// Shared collection across the long-lived-client pools so they
 	// all contend for the same address-map / chunk store.


### PR DESCRIPTION
The soak reported only a total error count and dropped the error text at every w.errors.Add(1) site, so a run showing "98 errors" gave no clue whether they were benign (merge/txn conflicts, maxTimeMS, shutdown context-cancel) or real.

Tally errors by a normalized signature: a short op tag plus a classification (server command-error name/code, write-error code, context canceled/deadline, network, or a digit-collapsed message so per-id and per-ns variation does not fragment buckets). Keep one example message per bucket and render a sorted breakdown in the summary email.