### PR TITLE
accept commitish arguments in merge commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,6 +19,23 @@ All versioning commands target a specific branch by encoding the branch name in 
 
 Use `db.getSiblingDB("mydb@feature")` in mongosh to connect to a branch.
 
+## Refspecs
+
+Command parameters that name a commit (`commit`, `onto`, `mergeIn`, `to`, `hash`, `base`, `targets`, `from`) accept any of these forms:
+
+| Form | Example | Meaning |
+|------|---------|---------|
+| Branch name | `feature` | That branch's tip commit |
+| Tag name | `v1.0` | The tagged commit |
+| Commit hash (32-char base32) | `na7kfra98...` | That commit |
+| Ancestor expression | `main~2` | Two first-parents above `main`'s tip |
+| Parent selection | `main^2` | Second parent (merge commits only); `^`/`^1` is the first parent, `^0` the commit itself |
+| Chained traversal | `main~1^2` | Applied left to right, as in git |
+| `HEAD` | `HEAD` | Tip of the branch encoded in the database name |
+| `HEAD` traversal | `HEAD~1`, `HEAD^2~3` | Traversal anchored at that branch tip |
+
+`HEAD` resolves against the connection's branch, not the default branch: on `mydb@feature`, `HEAD~1` means `feature~1`. Because DumboDB connections are stateless, `HEAD` is only valid in command parameters -- it is rejected in the connection string itself (`mydb@HEAD`), where a branch name must be used instead.
+
 ## Available Commands
 
 Every `dumbo*` command has an identical `dolt*` alias:
@@ -180,9 +197,7 @@ the reverse. Read-only.
 | `base` | string | **yes** |  -- | Base refspec to compare each target against |
 | `targets` | array of strings, or string | **yes** |  -- | Target refspecs; a single string is treated as a one-element array. Must name at least one target |
 
-A refspec is a commit hash, branch name, tag name, ancestor expression (`main~2`,
-`b2^1`), `HEAD`, or `HEAD~N`. `HEAD`/`HEAD~N` resolve against the branch encoded in
-the database name.
+See [Refspecs](#refspecs) for the accepted forms.
 
 ### Response fields
 
@@ -242,7 +257,7 @@ db.getSiblingDB("orders@main").runCommand({
 
 ## dumboMerge
 
-Merges a source branch into the branch encoded in the database name.
+Merges a source commit into the branch encoded in the database name. The source is usually a branch, but any [refspec](#refspecs) works.
 
 **Alias:** `doltMerge`
 
@@ -250,7 +265,7 @@ Merges a source branch into the branch encoded in the database name.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `mergeIn` | string | **yes** |  -- | Name of the branch to merge in |
+| `mergeIn` | string | **yes** |  -- | [Refspec](#refspecs) to merge in: branch, tag, commit hash, ancestor expression, or `HEAD` form |
 | `message` | string | no | auto | Merge commit message (ignored on fast-forward / already-up-to-date) |
 | `author` | string | no | `""` | `"Name <email>"` for the merge commit author |
 | `noFF` | bool | no | `false` | Force a merge commit even when fast-forward is possible |
@@ -316,6 +331,7 @@ main.runCommand({ dumboMerge: 1, abort: 1 })
 | Condition | Error |
 |-----------|-------|
 | `mergeIn` missing or empty | `BadValue: dumboMerge: from branch name must not be empty` |
+| `mergeIn` cannot be resolved | `OperationFailed: DumboDBMerge: resolving merge source ...` |
 | `noFF` and `ffOnly` both set | `BadValue: dumboMerge: noFF and ffOnly are mutually exclusive` |
 | Merge produces conflicts | `ok: 0` response with `conflicts` array |
 
@@ -324,6 +340,8 @@ main.runCommand({ dumboMerge: 1, abort: 1 })
 - When conflicts occur, the branch HEAD is unchanged; the staged working set reflects partial merge with "ours" values for conflicting documents.
 - Use `dumboConflicts` to inspect and `dumboResolveConflict` to resolve each conflict, then call `dumboMerge continue:1`.
 - `abort: 1` restores the branch to its pre-merge state.
+- The auto-generated message names the source the way git does: `Merge branch 'feature'`, `Merge tag 'v1.0'`, or `Merge commit '<refspec>'` for hashes and traversal expressions.
+- `mergeIn: "HEAD"` merges the connection's own branch, which is always `already up-to-date`.
 
 ---
 
@@ -337,7 +355,7 @@ Applies the diff introduced by a named commit onto the current branch, creating 
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `commit` | string | **yes** |  -- | Commit hash to cherry-pick |
+| `commit` | string | **yes** |  -- | [Refspec](#refspecs) of the commit to cherry-pick |
 | `message` | string | no | auto | Custom commit message (default: original message + annotation) |
 | `committer` | string | no |  -- | `"Name <email>"` committer identity. When omitted, committer equals the original commit's author. |
 
@@ -399,7 +417,7 @@ main.runCommand({ dumboCherryPick: 1, commit: "na7kfra98h45fr2u5qtr30o2ggm7vh61"
 
 | Condition | Error |
 |-----------|-------|
-| `commit` is an unsupported rootish form (HEAD, reflog, range, caret) | `BadValue: dumboCherryPick: ...` |
+| `commit` is an unsupported rootish form (reflog, range, `^{type}`) | `BadValue: dumboCherryPick: ...` |
 | Cherry-pick produces conflicts | `ok: 0` response with `conflicts` array |
 
 ---
@@ -414,7 +432,7 @@ Reapplies all commits on the current branch not reachable from `onto` onto the t
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `onto` | string | **yes** |  -- | Branch name or rootish to rebase onto |
+| `onto` | string | **yes** |  -- | [Refspec](#refspecs) to rebase onto |
 | `committer` | string | no |  -- | `"Name <email>"` committer identity for replayed commits. When omitted, committer equals the original commit's author. |
 
 ### Parameters (continue / abort)
@@ -826,8 +844,8 @@ Returns a document-level diff between two states for the branch encoded in the d
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `from` | string | no | HEAD | Starting rootish (commit hash, branch name, ancestor expression, or `"HEAD"`) |
-| `to` | string | no | working set | Ending rootish (same forms; omit to compare to current working set) |
+| `from` | string | no | HEAD | Starting [refspec](#refspecs) |
+| `to` | string | no | working set | Ending [refspec](#refspecs); omit to compare to the current working set |
 
 ### Response fields
 
@@ -937,7 +955,7 @@ Moves the branch HEAD to the specified commit. Supports soft (default) and hard 
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `to` | string | no | HEAD | Target commit hash |
+| `to` | string | no | HEAD | Target [refspec](#refspecs) |
 | `hard` | bool | no | `false` | Hard reset: also resets the working tree to the target commit |
 
 ### Response fields
@@ -994,7 +1012,7 @@ Applies the inverse diff of a named commit onto the current branch, creating a n
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `commit` | string | **yes** |  -- | Commit hash to revert |
+| `commit` | string | **yes** |  -- | [Refspec](#refspecs) of the commit to revert |
 | `message` | string | no | auto | Custom commit message |
 | `author` | string | no | `""` | `"Name <email>"` for the commit author |
 
@@ -1043,6 +1061,9 @@ const badCommitHash = log.commits[0].commitId
 
 // Revert it
 main.runCommand({ dumboRevert: 1, commit: badCommitHash })
+
+// Undo the most recent commit on this branch (same thing, by refspec)
+main.runCommand({ dumboRevert: 1, commit: "HEAD" })
 // {
 //   commitId:           "new-revert-hash...",
 //   message:            "Revert \"add order #1\"\n\nThis reverts commit <badCommitHash>.",
@@ -1358,7 +1379,7 @@ Create, list, or delete tags at specific commits. Tags are stored using Dolt's `
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `name` | string | no |  -- | Tag name. Required for create/delete. Must not contain `@` or whitespace. Omit to list all tags. |
-| `hash` | string | no | current branch HEAD | Rootish (commit hash, branch, tag, or ancestor expression) to tag |
+| `hash` | string | no | current branch HEAD | [Refspec](#refspecs) to tag |
 | `delete` | bool | no | `false` | Set to `true` to delete the named tag |
 | `message` | string | no | `""` | Tag description |
 | `author` | string | no | `"dumbodb <dumbodb@dumbodb>"` | Tagger identity "Name <email>" |

--- a/docs/verify/rootish.md
+++ b/docs/verify/rootish.md
@@ -205,9 +205,12 @@ db.getSiblingDB("verifydb@HEAD^").items.find({}).toArray()
 Key checks:
 - `HEAD`, `HEAD~N`, and `HEAD^` all return code 96
 
-> **Note:** `HEAD` is still accepted in command parameters like `dumboDiff`'s
-> `from` and `to` fields, where it resolves relative to the connection's branch.
-> It is only rejected in the connection string itself (`mydb@HEAD`).
+> **Note:** `HEAD` is still accepted in every command parameter that names a
+> commit (`dumboDiff` `from`/`to`, `dumboRevert`/`dumboCherryPick` `commit`,
+> `dumboRebase` `onto`, `dumboMerge` `mergeIn`, `dumboReset` `to`, `dumboTag`
+> `hash`, `dumboBranchStatus` `base`/`targets`), where it resolves relative to
+> the connection's branch. It is only rejected in the connection string itself
+> (`mydb@HEAD`).
 
 ---
 
@@ -393,6 +396,65 @@ db.getSiblingDB("verifydb@main%2E%2E%2Efeature").items.find({}).toArray()
 
 ---
 
+## Scenario 10: HEAD in command parameters
+
+Rejected in the connection string (Scenario 5), HEAD is accepted in every command
+parameter that names a commit, where it means the tip of the branch encoded in the
+database name. Automated analog: `tests/verify/head_rootish_test.go`.
+
+```js
+var main = db.getSiblingDB("verifydb@main")
+
+// Undo the most recent commit on this branch
+main.runCommand({ dumboRevert: 1, commit: "HEAD" })
+// { commitId: "<new-hash>", message: "Revert ... This reverts commit <old-tip>.", ok: 1 }
+
+// Traversal anchored at the branch tip
+main.runCommand({ dumboRevert: 1, commit: "HEAD~2" })
+main.runCommand({ dumboCherryPick: 1, commit: "HEAD~1" })
+main.runCommand({ dumboRebase: 1, onto: "HEAD~1" })
+// { commitsReplayed: 0, newTip: "<unchanged-tip>", ok: 1 }  -- onto is an ancestor
+
+// Tag the current tip and its parent
+main.runCommand({ dumboTag: 1, name: "at-head", hash: "HEAD" })
+main.runCommand({ dumboTag: 1, name: "at-head-1", hash: "HEAD~1" })
+
+// Merging your own branch changes nothing
+main.runCommand({ dumboMerge: 1, mergeIn: "HEAD" })
+// { commitId: "<tip>", message: "already up-to-date", ok: 1 }
+```
+
+On a different branch, HEAD follows the connection:
+
+```js
+db.getSiblingDB("verifydb@feature").runCommand({ dumboTag: 1, name: "feat-tip", hash: "HEAD" })
+// Tags feature's tip, not main's
+```
+
+`mergeIn` also accepts non-branch sources, which the merge message names the way
+git does:
+
+```js
+db.getSiblingDB("verifydb@feature").runCommand({ dumboMerge: 1, mergeIn: hash2 })
+// { commitId: "...", message: "Merge commit '<hash2>' into 'feature'", ok: 1 }
+
+db.getSiblingDB("verifydb@feature").runCommand({ dumboMerge: 1, mergeIn: "release-1" })
+// { commitId: "...", message: "Merge tag 'release-1' into 'feature'", ok: 1 }
+
+// Merge partway into another branch's history: two commits below feature's tip
+main.runCommand({ dumboMerge: 1, mergeIn: "feature~2" })
+// { commitId: "...", message: "Merge commit 'feature~2' into 'main'", ok: 1 }
+// main picks up feature's work only up to that commit; feature is untouched
+```
+
+Key checks:
+- `HEAD` resolves to the connection branch's tip, never to main's tip
+- `HEAD~N` and `HEAD^N` walk from that tip, and chain (`HEAD^2~3`)
+- `mergeIn` resolves branches, tags, hashes, and traversal expressions alike
+- `mergeIn: "<branch>~N"` merges the state at that ancestor, not the branch tip
+
+---
+
 ## Quick Reference
 
 | Rootish form | Example | Read | Write[1] | Branch creation[2] | Notes |
@@ -402,8 +464,8 @@ db.getSiblingDB("verifydb@main%2E%2E%2Efeature").items.find({}).toArray()
 | Tag name | `mydb@release-1` | yes | no | yes | Read-only; resolves to tagged commit |
 | Commit hash (32 chars) | `mydb@<hash>` | yes | no | yes | Read-only snapshot |
 | Ancestor expression | `mydb@main~1` | yes | no | yes | Read-only; walks first-parent chain |
-| HEAD | `mydb@HEAD` | no | no | no | Not supported in connection strings (code 96) |
-| HEAD-relative | `mydb@HEAD~N`, `mydb@HEAD^` | no | no | no | Not supported in connection strings (code 96) |
+| HEAD | `mydb@HEAD` | no | no | no | Not supported in connection strings (code 96); valid in command parameters (Scenario 10) |
+| HEAD-relative | `mydb@HEAD~N`, `mydb@HEAD^` | no | no | no | Not supported in connection strings (code 96); valid in command parameters (Scenario 10) |
 | Caret parent | `mydb@main^2` | yes | no | yes | Selects Nth parent (merge commits) |
 | Chained | `mydb@main^1~2`, `mydb@main^^` | yes | no | yes | Operators compose left to right |
 | Percent-encoded | `mydb@v1%2E0` (encodes `v1.0`) | yes | yes | yes | Decoded server-side |

--- a/internal/backends/dolt/backend.go
+++ b/internal/backends/dolt/backend.go
@@ -1611,15 +1611,29 @@ func dumboDBBranchDelete(ctx context.Context, db *dbState, params *backends.Bran
 	return &backends.BranchResult{Branch: params.Name}, nil
 }
 
+// refLabel describes a refspec the way git describes merge sources in commit
+// subjects and conflict descriptions: "branch 'feature'", "tag 'v1.0'", or
+// "commit '<refspec>'" for hashes and traversal expressions.
+func refLabel(ctx context.Context, db *dbState, ref string) string {
+	if ds, err := db.datasDB.GetDataset(ctx, "refs/heads/"+ref); err == nil && ds.HasHead() {
+		return fmt.Sprintf("branch '%s'", ref)
+	}
+	if ds, err := db.datasDB.GetDataset(ctx, tagRefPrefix+ref); err == nil && ds.HasHead() {
+		return fmt.Sprintf("tag '%s'", ref)
+	}
+	return fmt.Sprintf("commit '%s'", ref)
+}
+
 // DumboDBMerge implements backends.VersioningBackend.
 //
-// It merges the From branch into the Into branch of the specified database.
+// It merges From into the Into branch of the specified database. From is any
+// commit-ish: a branch name, tag, commit hash, or traversal expression.
 // Four cases are handled:
 //
 //   - Abort (Abort=true): discard the in-progress merge and restore the pre-merge state.
-//   - Already up-to-date: From's HEAD is an ancestor of (or equal to) Into's HEAD.
-//   - Fast-forward: Into's HEAD is an ancestor of From's HEAD; the Into pointer is
-//     simply advanced to From's HEAD without creating a new commit.
+//   - Already up-to-date: From is an ancestor of (or equal to) Into's HEAD.
+//   - Fast-forward: Into's HEAD is an ancestor of From; the Into pointer is
+//     simply advanced to From without creating a new commit.
 //   - True 3-way merge: a merge commit is created on the Into branch with both
 //     branch HEADs as parents. When document-level conflicts exist, the merge is staged
 //     but not committed; a *backends.MergeConflictError is returned and the caller must
@@ -1725,16 +1739,9 @@ func (b *Backend) DumboDBMerge(ctx context.Context, params *backends.MergeParams
 		return nil, fmt.Errorf("DumboDBMerge: into branch %q has no head address", params.Into)
 	}
 
-	fromBranchDS, err := db.datasDB.GetDataset(ctx, "refs/heads/"+params.From)
+	fromHash, err := resolveRootishToCommitHash(ctx, db, params.From)
 	if err != nil {
-		return nil, fmt.Errorf("DumboDBMerge: resolving from branch %q: %w", params.From, err)
-	}
-	if !fromBranchDS.HasHead() {
-		return nil, fmt.Errorf("DumboDBMerge: from branch %q has no commits", params.From)
-	}
-	fromHash, ok := fromBranchDS.MaybeHeadAddr()
-	if !ok {
-		return nil, fmt.Errorf("DumboDBMerge: from branch %q has no head address", params.From)
+		return nil, fmt.Errorf("DumboDBMerge: resolving merge source %q: %w", params.From, err)
 	}
 
 	intoCommit, err := datas.LoadCommitAddr(ctx, db.vs, intoHash)
@@ -1803,7 +1810,7 @@ func (b *Backend) DumboDBMerge(ctx context.Context, params *backends.MergeParams
 	}
 
 	mergedAM, conflicts, viewConflicts, metaConflicts, err := mergeAddressMapsWithConflicts(ctx, db, intoAM, fromAM, baseAM, fromHash, baseHash,
-		fmt.Sprintf("branch '%s' (ours)", params.Into), fmt.Sprintf("branch '%s' (theirs)", params.From))
+		fmt.Sprintf("branch '%s' (ours)", params.Into), fmt.Sprintf("%s (theirs)", refLabel(ctx, db, params.From)))
 	if err != nil {
 		return nil, fmt.Errorf("DumboDBMerge: %w", err)
 	}
@@ -1868,7 +1875,7 @@ func (b *Backend) commitMerge(
 ) (*backends.MergeResult, error) {
 	mergeMessage := message
 	if mergeMessage == "" {
-		mergeMessage = fmt.Sprintf("Merge branch '%s' into '%s'", fromBranch, intoBranch)
+		mergeMessage = fmt.Sprintf("Merge %s into '%s'", refLabel(ctx, db, fromBranch), intoBranch)
 	}
 
 	if author == "" {

--- a/internal/backends/dolt/merge_conflict.go
+++ b/internal/backends/dolt/merge_conflict.go
@@ -41,8 +41,9 @@ import (
 // automatically completed due to document-level conflicts. It persists in dbState
 // until the user resolves all conflicts.
 //
-// When isCherryPick is false: fromBranch and fromHash identify the source branch;
-// the final commit has two parents (intoHash and fromHash).
+// When isCherryPick is false: fromBranch is the source refspec as the caller
+// wrote it (branch, tag, hash, or traversal expression) and fromHash is the
+// commit it resolved to; the final commit has two parents (intoHash and fromHash).
 //
 // When isCherryPick is true: pickHash is the cherry-picked commit; intoHash is
 // the current branch HEAD; the final commit has one parent (intoHash).

--- a/internal/backends/dolt/merge_validation.go
+++ b/internal/backends/dolt/merge_validation.go
@@ -158,7 +158,7 @@ func (b *Backend) recheckCrossValidation(ctx context.Context, db *dbState, ms *m
 	}
 
 	before := unresolvedConflictCount(ms.conflicts)
-	theirsDesc := fmt.Sprintf("branch '%s' (theirs)", ms.fromBranch)
+	theirsDesc := fmt.Sprintf("%s (theirs)", refLabel(ctx, db, ms.fromBranch))
 	if err := crossValidateMergedDocuments(ctx, db, ms.resolvedAM, baseAM, ms.conflicts, ms.metaConflicts, ms.fromHash, theirsDesc, true); err != nil {
 		return false, err
 	}

--- a/internal/backends/versioning.go
+++ b/internal/backends/versioning.go
@@ -62,7 +62,7 @@ type BranchResult struct {
 type MergeParams struct {
 	DBName    string
 	Into      string // target branch (the current branch)
-	From      string // source branch to merge from
+	From      string // source commit-ish to merge from: branch, tag, commit hash, or traversal expression
 	Abort     bool   // if true, abort the in-progress merge and restore the pre-merge state
 	Continue  bool   // if true, resume after conflict resolution and create the merge commit
 	Message   string // optional: custom merge commit message (ignored on fast-forward and already-up-to-date)

--- a/internal/handler/msg_dumbodb_versioning.go
+++ b/internal/handler/msg_dumbodb_versioning.go
@@ -414,11 +414,31 @@ func branchFromDBName(encoded string) (dbName, rootish string, readOnly bool, er
 	return encoded, defaultBranch, false, nil
 }
 
+// isHEADRootish reports whether a refspec is anchored at HEAD: the bare word or
+// HEAD followed by a traversal operator. Names that merely begin with those four
+// letters (a branch called "HEADroom") are not HEAD-anchored.
+func isHEADRootish(rootish string) bool {
+	return rootish == "HEAD" || strings.HasPrefix(rootish, "HEAD~") || strings.HasPrefix(rootish, "HEAD^")
+}
+
+// resolveHEADRootish rewrites a HEAD-anchored refspec against the connection's
+// branch: "HEAD" -> "<branch>", "HEAD~2" -> "<branch>~2", "HEAD^2~1" -> "<branch>^2~1".
+//
+// DumboDB connections are stateless, so HEAD can only mean the tip of the branch
+// encoded in $db. Rewriting here keeps the backend resolver working on concrete
+// refs. Non-HEAD refspecs are returned unchanged.
+func resolveHEADRootish(rootish, branch string) string {
+	if !isHEADRootish(rootish) {
+		return rootish
+	}
+	return branch + rootish[len("HEAD"):]
+}
+
 // rejectHEAD returns an error if the rootish is HEAD or starts with HEAD~ / HEAD^.
 // DumboDB connections are stateless -- there is no per-session "current branch",
 // so HEAD has no meaning in the connection string. Use a branch name instead.
 func rejectHEAD(rootish string) error {
-	if rootish == "HEAD" || strings.HasPrefix(rootish, "HEAD~") || strings.HasPrefix(rootish, "HEAD^") {
+	if isHEADRootish(rootish) {
 		return handlererrors.NewCommandErrorMsg(
 			handlererrors.ErrOperationFailed,
 			fmt.Sprintf("rootish %q: HEAD is not supported in connection strings; use a branch name instead", rootish),
@@ -540,8 +560,9 @@ func enforceWritableRootish(encodedDB string) error {
 //   - Bare commit hash (full 32-char lowercase base32, i.e. 0-9a-v)
 //   - Relative ancestor expression (<branch>~<N>)
 //
-// Rejected by rejectHEAD (called separately after parseRootish):
-//   - HEAD, HEAD~N, HEAD^N (no per-session current branch in DumboDB)
+// HEAD-anchored forms (HEAD, HEAD~N, HEAD^N) pass validation here. Command
+// parameters resolve them against the connection's branch via resolveHEADRootish;
+// connection strings reject them via rejectHEAD.
 //
 // Rejected forms (returned as ErrOperationFailed):
 //   - Any '@' (reserved as the database/branch delimiter; covers reflog <ref>@{...} too)
@@ -803,7 +824,11 @@ func (h *Handler) MsgDumboDBBranch(connCtx context.Context, msg *wire.OpMsg) (*w
 
 // MsgDumboDBMerge implements the `dumboDBMerge` command.
 //
-// Merges a source branch into the current branch encoded in $db (format: "dbname@branch").
+// Merges a source commit-ish into the current branch encoded in $db (format:
+// "dbname@branch"). mergeIn is usually a branch name, but any hash, tag,
+// traversal expression, or HEAD-anchored form is accepted; HEAD resolves against
+// the branch encoded in $db.
+//
 // Usage:
 //
 //	db.getSiblingDB("mydb@main").runCommand({dumboDBMerge: 1, mergeIn: "feature"})
@@ -966,6 +991,15 @@ func (h *Handler) MsgDumboDBMerge(connCtx context.Context, msg *wire.OpMsg) (*wi
 			"mergeIn",
 		)
 	}
+
+	if err := parseRootish(fromBranch); err != nil {
+		return nil, handlererrors.NewCommandErrorMsgWithArgument(
+			handlererrors.ErrBadValue,
+			"dumboMerge: "+err.Error(),
+			"mergeIn",
+		)
+	}
+	fromBranch = resolveHEADRootish(fromBranch, intoBranch)
 
 	message, err := common.GetOptionalParam[string](document, "message", "")
 	if err != nil {
@@ -1712,13 +1746,7 @@ func (h *Handler) MsgDumboDBBranchStatus(connCtx context.Context, msg *wire.OpMs
 			return "", handlererrors.NewCommandErrorMsgWithArgument(
 				handlererrors.ErrBadValue, "dumboBranchStatus: "+perr.Error(), argName)
 		}
-		if s == "HEAD" {
-			return branch, nil
-		}
-		if strings.HasPrefix(s, "HEAD~") {
-			return branch + s[len("HEAD"):], nil
-		}
-		return s, nil
+		return resolveHEADRootish(s, branch), nil
 	}
 
 	resolvedBase, err := rewriteHead(base, "base")
@@ -1826,14 +1854,7 @@ func (h *Handler) MsgDumboDBReset(connCtx context.Context, msg *wire.OpMsg) (*wi
 				"to",
 			)
 		}
-		// HEAD / HEAD~N target the connection's branch, not the literal default.
-		// Rewrite to <branch> / <branch>~N so the backend's rootish resolver sees
-		// a concrete branch reference.
-		if to == "HEAD" {
-			to = branch
-		} else if strings.HasPrefix(to, "HEAD~") {
-			to = branch + to[len("HEAD"):]
-		}
+		to = resolveHEADRootish(to, branch)
 	}
 
 	hard, err := common.GetOptionalParam[bool](document, "hard", false)
@@ -1963,9 +1984,13 @@ func (h *Handler) MsgDumboDBStatus(connCtx context.Context, msg *wire.OpMsg) (*w
 // committed; use dumboDBConflicts / dumboDBResolveConflict to inspect and resolve
 // conflicts, then dumboCherryPick continue:true to complete.
 //
+// commit is any commit-ish: a hash, branch, tag, traversal expression, or a
+// HEAD-anchored form resolved against the branch encoded in $db.
+//
 // Usage:
 //
 //	db.getSiblingDB("mydb@main").runCommand({dumboDBCherryPick: 1, commit: "<hash>"})
+//	db.getSiblingDB("mydb@main").runCommand({dumboDBCherryPick: 1, commit: "feature~1"})
 //	db.getSiblingDB("mydb@main").runCommand({dumboDBCherryPick: 1, abort: 1})
 //	db.getSiblingDB("mydb@main").runCommand({dumboDBCherryPick: 1, continue: 1})
 //
@@ -2086,6 +2111,7 @@ func (h *Handler) MsgDumboDBCherryPick(connCtx context.Context, msg *wire.OpMsg)
 			"commit",
 		)
 	}
+	commit = resolveHEADRootish(commit, branch)
 
 	message, err := common.GetOptionalParam[string](document, "message", "")
 	if err != nil {
@@ -2160,6 +2186,9 @@ func (h *Handler) MsgDumboDBCherryPick(connCtx context.Context, msg *wire.OpMsg)
 // onto the tip of Onto, rewriting branch history. On conflict, the rebase is paused;
 // use doltConflicts / doltResolveConflict to inspect and resolve conflicts, then
 // doltRebase continue:true to proceed.
+//
+// onto is any commit-ish: a hash, branch, tag, traversal expression, or a
+// HEAD-anchored form resolved against the branch encoded in $db.
 //
 // Usage:
 //
@@ -2294,6 +2323,7 @@ func (h *Handler) MsgDumboDBRebase(connCtx context.Context, msg *wire.OpMsg) (*w
 			"onto",
 		)
 	}
+	onto = resolveHEADRootish(onto, branch)
 
 	res, rebaseErr := vb.DumboDBRebase(connCtx, &backends.RebaseParams{
 		DBName:    dbName,
@@ -2342,9 +2372,13 @@ func (h *Handler) MsgDumboDBRebase(connCtx context.Context, msg *wire.OpMsg) (*w
 // but not committed; use doltConflicts / doltResolveConflict to inspect and resolve
 // conflicts, then doltRevert continue:true to complete. Use abort:true to abandon.
 //
+// commit is any commit-ish: a hash, branch, tag, traversal expression, or a
+// HEAD-anchored form resolved against the branch encoded in $db.
+//
 // Usage:
 //
 //	db.getSiblingDB("mydb@main").runCommand({doltRevert: 1, commit: "<hash>"})
+//	db.getSiblingDB("mydb@main").runCommand({doltRevert: 1, commit: "HEAD"})
 //	db.getSiblingDB("mydb@main").runCommand({doltRevert: 1, abort: 1})
 //	db.getSiblingDB("mydb@main").runCommand({doltRevert: 1, continue: 1})
 func (h *Handler) MsgDumboDBRevert(connCtx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
@@ -2454,6 +2488,7 @@ func (h *Handler) MsgDumboDBRevert(connCtx context.Context, msg *wire.OpMsg) (*w
 			"commit",
 		)
 	}
+	commit = resolveHEADRootish(commit, branch)
 
 	message, err := common.GetOptionalParam[string](document, "message", "")
 	if err != nil {
@@ -2523,7 +2558,7 @@ func (h *Handler) MsgDumboDBRevert(connCtx context.Context, msg *wire.OpMsg) (*w
 // Usage:
 //
 //	db.runCommand({dumboTag: 1})                                       // list all tags
-//	db.runCommand({dumboTag: 1, name: "v1.0", hash: "<rootish>"})      // create tag at rootish
+//	db.runCommand({dumboTag: 1, name: "v1.0", hash: "<rootish>"})      // create tag at rootish (HEAD forms allowed)
 //	db.runCommand({dumboTag: 1, name: "v1.0"})                         // create tag at current branch HEAD
 //	db.runCommand({dumboTag: 1, name: "v1.0", delete: true})           // delete tag
 //
@@ -2569,6 +2604,7 @@ func (h *Handler) MsgDumboDBTag(connCtx context.Context, msg *wire.OpMsg) (*wire
 	if err != nil {
 		return nil, err
 	}
+	tagHash = resolveHEADRootish(tagHash, branch)
 
 	message, err := common.GetOptionalParam[string](document, "message", "")
 	if err != nil {

--- a/internal/handler/msg_dumbodb_versioning_test.go
+++ b/internal/handler/msg_dumbodb_versioning_test.go
@@ -264,3 +264,44 @@ func TestEnforceWritableRootish(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveHEADRootish(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		rootish string
+		branch  string
+		want    string
+	}{
+		// HEAD-anchored forms resolve against the connection branch.
+		{"HEAD", "main", "main"},
+		{"HEAD", "feature", "feature"},
+		{"HEAD~1", "main", "main~1"},
+		{"HEAD~0", "feature", "feature~0"},
+		{"HEAD~10", "release/v2", "release/v2~10"},
+		{"HEAD^", "main", "main^"},
+		{"HEAD^2", "main", "main^2"},
+		{"HEAD^2~3", "feature", "feature^2~3"},
+		{"HEAD~1^2", "main", "main~1^2"},
+
+		// Names that merely start with "HEAD" are left alone.
+		{"HEADroom", "main", "HEADroom"},
+		{"HEADS", "main", "HEADS"},
+		{"head", "main", "head"},
+
+		// Other refspecs pass through untouched.
+		{"main", "feature", "main"},
+		{"v1.0", "main", "v1.0"},
+		{"main~2", "feature", "main~2"},
+		{"na7kfra98h45fr2u5qtr30o2ggm7vh61", "main", "na7kfra98h45fr2u5qtr30o2ggm7vh61"},
+		{"", "main", ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.rootish, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, resolveHEADRootish(tt.rootish, tt.branch))
+		})
+	}
+}

--- a/tests/verify/head_rootish_test.go
+++ b/tests/verify/head_rootish_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+// TestHEADRootish* are the automated analog of Scenario 10 in
+// docs/verify/rootish.md.
+//
+// HEAD-anchored refspecs (HEAD, HEAD~N, HEAD^N) resolve against the branch
+// encoded in $db, so every command that takes a commit-ish accepts them. These
+// tests cover the commands that resolve one: dumboRevert, dumboCherryPick,
+// dumboRebase, dumboTag and dumboMerge. dumboReset and dumboBranchStatus have
+// their own coverage in reset_test.go and branch_status_test.go.
+//
+// dumboMerge additionally accepts non-branch commit-ish sources (hashes, tags,
+// traversal expressions), which is exercised here too.
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// headTestDB creates a fresh database whose main branch holds one commit per
+// entry in inserts: commit i inserts {_id: i+1}. It returns the commit hashes
+// oldest-first.
+func headTestDB(t *testing.T, env *dumboDBTestEnv, dbName string, commits int) []string {
+	t.Helper()
+
+	ctx := context.Background()
+	db := env.Client.Database(dbName)
+	require.NoError(t, db.Drop(ctx))
+
+	hashes := make([]string, 0, commits)
+	for i := 1; i <= commits; i++ {
+		_, err := db.Collection("records").InsertOne(ctx, bson.D{{Key: "_id", Value: int32(i)}})
+		require.NoError(t, err)
+		hashes = append(hashes, dumboDBCommit(t, env, dbName, fmt.Sprintf("c%d", i), "alice <alice@acme.com>"))
+	}
+	return hashes
+}
+
+// recordIDs returns the _id values in the records collection, sorted ascending
+// so assertions do not depend on storage order.
+func recordIDs(t *testing.T, env *dumboDBTestEnv, dbName string) []int {
+	t.Helper()
+
+	ctx := context.Background()
+	cur, err := env.Client.Database(dbName).Collection("records").Find(ctx, bson.D{})
+	require.NoError(t, err)
+
+	var docs []bson.M
+	require.NoError(t, cur.All(ctx, &docs))
+
+	ids := make([]int, 0, len(docs))
+	for _, d := range docs {
+		ids = append(ids, toInt(d["_id"]))
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+func TestHEADRootishRevert(t *testing.T) {
+	env := startDumboDB(t)
+
+	dbName := fmt.Sprintf("headrevert%d", rand.Int64N(1_000_000))
+	hashes := headTestDB(t, env, dbName, 3)
+	mainDB := env.Client.Database(dbName + "@main")
+
+	// HEAD is the tip commit (c3, which inserted _id:3).
+	t.Run("Revert_HEAD", func(t *testing.T) {
+		raw := runCommandRaw(t, mainDB, bson.D{
+			{Key: "dumboRevert", Value: int32(1)},
+			{Key: "commit", Value: "HEAD"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboRevert HEAD must succeed: %v", raw["errmsg"])
+
+		msg, ok := raw["message"].(string)
+		require.True(t, ok, "message must be a string")
+		assert.Contains(t, msg, hashes[2], "revert must annotate the tip commit hash")
+
+		assert.Equal(t, []int{1, 2}, recordIDs(t, env, dbName+"@main"),
+			"reverting HEAD must undo the tip commit's insert")
+	})
+
+	// After the revert the tip is the revert commit, so HEAD~1 is c3 and
+	// HEAD~2 is c2 (the commit that inserted _id:2).
+	t.Run("Revert_HEADTilde", func(t *testing.T) {
+		raw := runCommandRaw(t, mainDB, bson.D{
+			{Key: "dumboRevert", Value: int32(1)},
+			{Key: "commit", Value: "HEAD~2"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboRevert HEAD~2 must succeed: %v", raw["errmsg"])
+
+		msg, ok := raw["message"].(string)
+		require.True(t, ok, "message must be a string")
+		assert.Contains(t, msg, hashes[1], "revert must annotate the commit HEAD~2 resolved to")
+
+		assert.Equal(t, []int{1}, recordIDs(t, env, dbName+"@main"),
+			"reverting HEAD~2 must undo the _id:2 insert")
+	})
+
+	// A caret chain resolves the same way: HEAD^ is the first parent.
+	t.Run("Revert_HEADCaret", func(t *testing.T) {
+		raw := runCommandRaw(t, mainDB, bson.D{
+			{Key: "dumboRevert", Value: int32(1)},
+			{Key: "commit", Value: "HEAD^"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboRevert HEAD^ must succeed: %v", raw["errmsg"])
+		assert.Equal(t, []int{1, 3}, recordIDs(t, env, dbName+"@main"),
+			"reverting HEAD^ must undo the previous revert, restoring _id:3")
+	})
+}
+
+func TestHEADRootishCherryPick(t *testing.T) {
+	env := startDumboDB(t)
+	ctx := context.Background()
+
+	dbName := fmt.Sprintf("headpick%d", rand.Int64N(1_000_000))
+	hashes := headTestDB(t, env, dbName, 2)
+	mainDB := env.Client.Database(dbName + "@main")
+
+	// c3 removes the document c2 added, so HEAD~1 (c2) can be replayed cleanly.
+	_, err := mainDB.Collection("records").DeleteOne(ctx, bson.D{{Key: "_id", Value: int32(2)}})
+	require.NoError(t, err)
+	dumboDBCommit(t, env, dbName, "c3", "alice <alice@acme.com>")
+
+	require.Equal(t, []int{1}, recordIDs(t, env, dbName+"@main"), "setup: _id:2 must be gone")
+
+	raw := runCommandRaw(t, mainDB, bson.D{
+		{Key: "dumboCherryPick", Value: int32(1)},
+		{Key: "commit", Value: "HEAD~1"},
+	})
+
+	require.EqualValues(t, 1, raw["ok"], "dumboCherryPick HEAD~1 must succeed: %v", raw["errmsg"])
+
+	msg, ok := raw["message"].(string)
+	require.True(t, ok, "message must be a string")
+	assert.Contains(t, msg, hashes[1], "cherry-pick must annotate the commit HEAD~1 resolved to")
+
+	assert.Equal(t, []int{1, 2}, recordIDs(t, env, dbName+"@main"),
+		"cherry-picking HEAD~1 must re-apply the _id:2 insert")
+}
+
+func TestHEADRootishRebase(t *testing.T) {
+	env := startDumboDB(t)
+
+	dbName := fmt.Sprintf("headrebase%d", rand.Int64N(1_000_000))
+	hashes := headTestDB(t, env, dbName, 2)
+
+	// HEAD~1 is an ancestor of the branch tip, so the branch already sits on
+	// top of onto: nothing is replayed. The point is that the refspec resolves
+	// at all -- it used to fail with "not found as commit hash, branch, or tag".
+	raw := runCommandRaw(t, env.Client.Database(dbName+"@main"), bson.D{
+		{Key: "dumboRebase", Value: int32(1)},
+		{Key: "onto", Value: "HEAD~1"},
+	})
+
+	require.EqualValues(t, 1, raw["ok"], "dumboRebase onto HEAD~1 must succeed: %v", raw["errmsg"])
+	assert.EqualValues(t, 0, toInt(raw["commitsReplayed"]), "onto is an ancestor, so nothing replays")
+	assert.Equal(t, hashes[1], raw["newTip"], "branch tip must be untouched")
+}
+
+func TestHEADRootishTag(t *testing.T) {
+	env := startDumboDB(t)
+
+	dbName := fmt.Sprintf("headtag%d", rand.Int64N(1_000_000))
+	hashes := headTestDB(t, env, dbName, 2)
+
+	mainDB := env.Client.Database(dbName + "@main")
+
+	raw := runCommandRaw(t, mainDB, bson.D{
+		{Key: "dumboTag", Value: int32(1)},
+		{Key: "name", Value: "at-head"},
+		{Key: "hash", Value: "HEAD"},
+	})
+	require.EqualValues(t, 1, raw["ok"], "dumboTag at HEAD must succeed: %v", raw["errmsg"])
+	assert.Equal(t, hashes[1], raw["commitId"], "tag must point at the branch tip")
+
+	raw = runCommandRaw(t, mainDB, bson.D{
+		{Key: "dumboTag", Value: int32(1)},
+		{Key: "name", Value: "at-head-1"},
+		{Key: "hash", Value: "HEAD~1"},
+	})
+	require.EqualValues(t, 1, raw["ok"], "dumboTag at HEAD~1 must succeed: %v", raw["errmsg"])
+	assert.Equal(t, hashes[0], raw["commitId"], "tag must point at the tip's parent")
+}
+
+func TestHEADRootishMerge(t *testing.T) {
+	env := startDumboDB(t)
+	ctx := context.Background()
+
+	dbName := fmt.Sprintf("headmerge%d", rand.Int64N(1_000_000))
+	hashes := headTestDB(t, env, dbName, 3)
+
+	mainDB := env.Client.Database(dbName + "@main")
+
+	// Merging the connection's own tip is a self-merge: already up-to-date.
+	t.Run("MergeIn_HEAD", func(t *testing.T) {
+		raw := runCommandRaw(t, mainDB, bson.D{
+			{Key: "dumboMerge", Value: int32(1)},
+			{Key: "mergeIn", Value: "HEAD"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboMerge HEAD must succeed: %v", raw["errmsg"])
+		assert.Equal(t, "already up-to-date", raw["message"], "merging HEAD into itself changes nothing")
+		assert.Equal(t, hashes[2], raw["commitId"], "branch tip must be untouched")
+	})
+
+	// An ancestor is already merged; the refspec still has to resolve.
+	t.Run("MergeIn_HEADTilde", func(t *testing.T) {
+		raw := runCommandRaw(t, mainDB, bson.D{
+			{Key: "dumboMerge", Value: int32(1)},
+			{Key: "mergeIn", Value: "HEAD~1"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboMerge HEAD~1 must succeed: %v", raw["errmsg"])
+		assert.Equal(t, "already up-to-date", raw["message"], "an ancestor is already merged")
+	})
+
+	// A bare commit hash is a valid merge source: feature diverged from c1, so
+	// merging c2 (which main reached long ago) is a real three-way merge.
+	t.Run("MergeIn_CommitHash", func(t *testing.T) {
+		bsBranchCreate(t, env, dbName, hashes[0], "feature")
+
+		featureDB := env.Client.Database(dbName + "@feature")
+		_, err := featureDB.Collection("records").InsertOne(ctx, bson.D{{Key: "_id", Value: int32(99)}})
+		require.NoError(t, err)
+		dumboDBCommit(t, env, dbName+"@feature", "feature work", "bob <bob@widgets.io>")
+
+		raw := runCommandRaw(t, featureDB, bson.D{
+			{Key: "dumboMerge", Value: int32(1)},
+			{Key: "mergeIn", Value: hashes[1]},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboMerge of a bare commit hash must succeed: %v", raw["errmsg"])
+
+		msg, ok := raw["message"].(string)
+		require.True(t, ok, "message must be a string")
+		assert.Contains(t, msg, "Merge commit '"+hashes[1]+"'",
+			"a non-branch source must be described as a commit, not a branch")
+
+		assert.Equal(t, []int{1, 2, 99}, recordIDs(t, env, dbName+"@feature"),
+			"feature must gain the document from the merged commit")
+	})
+
+	// A traversal expression names the same commit as a hash and merges the same
+	// way; only the message differs, since it echoes the refspec as written.
+	t.Run("MergeIn_TraversalExpression", func(t *testing.T) {
+		bsBranchCreate(t, env, dbName, hashes[0], "feature2")
+
+		feature2DB := env.Client.Database(dbName + "@feature2")
+		_, err := feature2DB.Collection("records").InsertOne(ctx, bson.D{{Key: "_id", Value: int32(98)}})
+		require.NoError(t, err)
+		dumboDBCommit(t, env, dbName+"@feature2", "feature2 work", "bob <bob@widgets.io>")
+
+		raw := runCommandRaw(t, feature2DB, bson.D{
+			{Key: "dumboMerge", Value: int32(1)},
+			{Key: "mergeIn", Value: "main~1"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboMerge of a traversal expression must succeed: %v", raw["errmsg"])
+
+		msg, ok := raw["message"].(string)
+		require.True(t, ok, "message must be a string")
+		assert.Contains(t, msg, "Merge commit 'main~1'", "a traversal expression is not a branch")
+
+		assert.Equal(t, []int{1, 2, 98}, recordIDs(t, env, dbName+"@feature2"),
+			"feature2 must gain the document from main~1")
+	})
+
+	// A tag resolves as a merge source too, and reads as a tag in the message.
+	t.Run("MergeIn_Tag", func(t *testing.T) {
+		bsTag(t, env, dbName+"@main", "v-tip", hashes[2])
+
+		raw := runCommandRaw(t, env.Client.Database(dbName+"@feature"), bson.D{
+			{Key: "dumboMerge", Value: int32(1)},
+			{Key: "mergeIn", Value: "v-tip"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboMerge of a tag must succeed: %v", raw["errmsg"])
+
+		msg, ok := raw["message"].(string)
+		require.True(t, ok, "message must be a string")
+		assert.Contains(t, msg, "Merge tag 'v-tip'", "a tag source must be described as a tag")
+
+		assert.Equal(t, []int{1, 2, 3, 99}, recordIDs(t, env, dbName+"@feature"),
+			"feature must gain the document from the tagged commit")
+	})
+
+	// Merging partway into another branch's history: side~2 is two commits below
+	// that branch's tip, so main must pick up only the work up to that point.
+	// This is the case that distinguishes resolving the expression from resolving
+	// the branch it is anchored on.
+	t.Run("MergeIn_SideBranchAncestor", func(t *testing.T) {
+		bsBranchCreate(t, env, dbName, hashes[0], "side")
+
+		sideDB := env.Client.Database(dbName + "@side")
+		for _, id := range []int32{101, 102, 103} {
+			_, err := sideDB.Collection("records").InsertOne(ctx, bson.D{{Key: "_id", Value: id}})
+			require.NoError(t, err)
+			dumboDBCommit(t, env, dbName+"@side", fmt.Sprintf("side %d", id), "bob <bob@widgets.io>")
+		}
+
+		raw := runCommandRaw(t, mainDB, bson.D{
+			{Key: "dumboMerge", Value: int32(1)},
+			{Key: "mergeIn", Value: "side~2"},
+		})
+
+		require.EqualValues(t, 1, raw["ok"], "dumboMerge of side~2 must succeed: %v", raw["errmsg"])
+
+		msg, ok := raw["message"].(string)
+		require.True(t, ok, "message must be a string")
+		assert.Contains(t, msg, "Merge commit 'side~2'", "the message echoes the refspec as written")
+
+		assert.Equal(t, []int{1, 2, 3, 101}, recordIDs(t, env, dbName+"@main"),
+			"main must gain only the work committed at side~2, not side's later commits")
+
+		assert.Equal(t, []int{1, 101, 102, 103}, recordIDs(t, env, dbName+"@side"),
+			"the source branch must be untouched")
+	})
+}


### PR DESCRIPTION
dumboMerge resolved mergeIn as refs/heads/<name> and nothing else, so hashes, tags and ancestor expressions were all rejected. This change addresses that gap.