### PR TITLE
insert, update: opt-in dumboDocHashes — return each written document's content hash

### DIFF
--- a/internal/backends/collection.go
+++ b/internal/backends/collection.go
@@ -271,9 +271,18 @@ type InsertAllParams struct {
 	// Backends that support it may acknowledge before the write is durable and
 	// rely on a periodic background flush.
 	SkipDurableSync bool
+
+	// ReturnDocHashes asks the backend to report the content hash of every
+	// stored document in InsertAllResult.DocHashes.
+	ReturnDocHashes bool
 }
 
-type InsertAllResult struct{}
+type InsertAllResult struct {
+	// DocHashes holds the content hash of each stored document, in Docs order,
+	// when ReturnDocHashes was set; nil otherwise. A backend that does not
+	// address documents by content leaves it nil.
+	DocHashes []string
+}
 
 // InsertAll inserts documents into the collection.
 //
@@ -319,6 +328,10 @@ type UpdateAllParams struct {
 	// SkipDurableSync, when true, tells the backend the client opted out of a
 	// synchronous journal fsync via MongoDB writeConcern. See InsertAllParams.
 	SkipDurableSync bool
+
+	// ReturnDocHashes asks the backend to report the content hash of every
+	// stored document in UpdateAllResult.DocHashes.
+	ReturnDocHashes bool
 }
 
 // FieldMutation describes a single field-level change applied to a document.
@@ -345,6 +358,11 @@ type FieldMutation struct {
 
 type UpdateAllResult struct {
 	Updated int32
+
+	// DocHashes has one entry per Docs entry when ReturnDocHashes was set,
+	// holding the content hash of the document as stored; nil otherwise.
+	// Entry i is empty when Docs[i] matched nothing and was not written.
+	DocHashes []string
 }
 
 // UpdateAll updates documents in collection.

--- a/internal/backends/dolt/collection.go
+++ b/internal/backends/dolt/collection.go
@@ -1492,6 +1492,11 @@ func (c *collection) InsertAll(ctx context.Context, params *backends.InsertAllPa
 
 	mut := m.Mutate()
 
+	var docHashes []string
+	if params.ReturnDocHashes {
+		docHashes = make([]string, 0, len(params.Docs))
+	}
+
 	// batchHashSet detects in-batch duplicate _id hashes in O(1).
 	batchHashSet := make(map[[20]byte]struct{}, len(params.Docs))
 	// In-batch collated string _ids (the primary probe only sees pre-batch state).
@@ -1626,13 +1631,22 @@ func (c *collection) InsertAll(ctx context.Context, params *backends.InsertAllPa
 			return nil, err
 		}
 
-		v, err := writeDocToValue(ctx, state.ns, doc)
+		stored, err := docToBSON(doc)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := buildValue(ctx, state.ns, stored)
 		if err != nil {
 			return nil, err
 		}
 
 		if err := mut.Put(ctx, key, v); err != nil {
 			return nil, err
+		}
+
+		if params.ReturnDocHashes {
+			docHashes = append(docHashes, docContentHash(stored).String())
 		}
 
 		batchHashSet[h] = struct{}{}
@@ -1674,7 +1688,7 @@ func (c *collection) InsertAll(ctx context.Context, params *backends.InsertAllPa
 		return nil, err
 	}
 
-	return &backends.InsertAllResult{}, nil
+	return &backends.InsertAllResult{DocHashes: docHashes}, nil
 }
 
 func existsID(ctx context.Context, m prolly.Map, h [20]byte) (bool, error) {
@@ -1726,6 +1740,12 @@ func (c *collection) UpdateAll(ctx context.Context, params *backends.UpdateAllPa
 	mut := m.Mutate()
 
 	var updated int32
+
+	// Entry i stays empty when Docs[i] matched nothing.
+	var docHashes []string
+	if params.ReturnDocHashes {
+		docHashes = make([]string, len(params.Docs))
+	}
 
 	// Resolved once per batch: backs unique probes and the entry
 	// maintenance after the loop.
@@ -1833,6 +1853,10 @@ func (c *collection) UpdateAll(ctx context.Context, params *backends.UpdateAllPa
 			return nil, err
 		}
 
+		if params.ReturnDocHashes {
+			docHashes[i] = docContentHash(newBytes).String()
+		}
+
 		idxOldDocs = append(idxOldDocs, oldDoc)
 		idxNewDocs = append(idxNewDocs, newDoc)
 
@@ -1868,7 +1892,7 @@ func (c *collection) UpdateAll(ctx context.Context, params *backends.UpdateAllPa
 		return nil, err
 	}
 
-	return &backends.UpdateAllResult{Updated: updated}, nil
+	return &backends.UpdateAllResult{Updated: updated, DocHashes: docHashes}, nil
 }
 
 func (c *collection) DeleteAll(ctx context.Context, params *backends.DeleteAllParams) (*backends.DeleteAllResult, error) {

--- a/internal/backends/dolt/doc_hash_test.go
+++ b/internal/backends/dolt/doc_hash_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dolt
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dumbodb/internal/backends"
+	"github.com/dolthub/dumbodb/internal/types"
+)
+
+func docHashBackend(t *testing.T) (context.Context, backends.Collection) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "dolt-doc-hash-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	ctx := context.Background()
+	b := &Backend{
+		dataDir: dir,
+		l:       slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		dbs:     make(map[string]*dbState),
+	}
+	t.Cleanup(b.Close)
+
+	_, err = b.getOrOpenDB(ctx, "hashdb", true)
+	require.NoError(t, err)
+
+	db, err := b.Database("hashdb")
+	require.NoError(t, err)
+	coll, err := db.Collection("col")
+	require.NoError(t, err)
+
+	return ctx, coll
+}
+
+func docHashDoc(t *testing.T, pairs ...any) *types.Document {
+	t.Helper()
+
+	doc, err := types.NewDocument(pairs...)
+	require.NoError(t, err)
+	return doc
+}
+
+// The hash a write reports is the hash of the canonical stored bytes, so a
+// client that hashes the same document reaches the same answer.
+func TestDocHashMatchesStoredBytes(t *testing.T) {
+	ctx, coll := docHashBackend(t)
+
+	doc := docHashDoc(t, "_id", int64(1), "a", "x")
+	res, err := coll.InsertAll(ctx, &backends.InsertAllParams{
+		Docs:            []*types.Document{doc},
+		ReturnDocHashes: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.DocHashes, 1)
+
+	stored, err := docToBSON(doc)
+	require.NoError(t, err)
+	require.Equal(t, docContentHash(stored).String(), res.DocHashes[0])
+	require.Len(t, res.DocHashes[0], 32, "hashes render as 32-character base32, like commit hashes")
+}
+
+// Field order on the wire does not reach storage: the codec sorts keys at
+// every level, so the same content has one hash.
+func TestDocHashIgnoresFieldOrder(t *testing.T) {
+	first, err := docToBSON(docHashDoc(t, "_id", int64(1), "b", int64(2), "a", int64(1)))
+	require.NoError(t, err)
+	second, err := docToBSON(docHashDoc(t, "_id", int64(1), "a", int64(1), "b", int64(2)))
+	require.NoError(t, err)
+
+	require.Equal(t, docContentHash(first), docContentHash(second))
+}
+
+// The hash follows the content: it moves when a field changes and returns to
+// its earlier value when the earlier content is written again.
+func TestDocHashFollowsContent(t *testing.T) {
+	ctx, coll := docHashBackend(t)
+
+	ins, err := coll.InsertAll(ctx, &backends.InsertAllParams{
+		Docs:            []*types.Document{docHashDoc(t, "_id", int64(1), "a", "x")},
+		ReturnDocHashes: true,
+	})
+	require.NoError(t, err)
+	original := ins.DocHashes[0]
+
+	upd, err := coll.UpdateAll(ctx, &backends.UpdateAllParams{
+		Docs:            []*types.Document{docHashDoc(t, "_id", int64(1), "a", "y")},
+		ReturnDocHashes: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), upd.Updated)
+	require.Len(t, upd.DocHashes, 1)
+	require.NotEqual(t, original, upd.DocHashes[0])
+
+	back, err := coll.UpdateAll(ctx, &backends.UpdateAllParams{
+		Docs:            []*types.Document{docHashDoc(t, "_id", int64(1), "a", "x")},
+		ReturnDocHashes: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, original, back.DocHashes[0], "identical content must hash identically")
+}
+
+// Distinct documents hash distinctly, and a document stored out of band (over
+// the tuple-builder threshold) is hashed like any other: the hash covers the
+// stored bytes, not the storage shape.
+func TestDocHashCoversEveryStorageShape(t *testing.T) {
+	ctx, coll := docHashBackend(t)
+
+	small := docHashDoc(t, "_id", int64(1), "a", "x")
+	large := docHashDoc(t, "_id", int64(2), "a", strings.Repeat("q", 8*1024))
+
+	res, err := coll.InsertAll(ctx, &backends.InsertAllParams{
+		Docs:            []*types.Document{small, large},
+		ReturnDocHashes: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.DocHashes, 2)
+	require.NotEqual(t, res.DocHashes[0], res.DocHashes[1])
+
+	for _, h := range res.DocHashes {
+		require.NotEmpty(t, h)
+	}
+
+	largeBytes, err := docToBSON(large)
+	require.NoError(t, err)
+	require.Equal(t, docContentHash(largeBytes).String(), res.DocHashes[1])
+}
+
+// Nothing is computed for a caller that did not ask.
+func TestDocHashAbsentUnlessRequested(t *testing.T) {
+	ctx, coll := docHashBackend(t)
+
+	ins, err := coll.InsertAll(ctx, &backends.InsertAllParams{
+		Docs: []*types.Document{docHashDoc(t, "_id", int64(1), "a", "x")},
+	})
+	require.NoError(t, err)
+	require.Nil(t, ins.DocHashes)
+
+	upd, err := coll.UpdateAll(ctx, &backends.UpdateAllParams{
+		Docs: []*types.Document{docHashDoc(t, "_id", int64(1), "a", "y")},
+	})
+	require.NoError(t, err)
+	require.Nil(t, upd.DocHashes)
+}
+
+// A document that matches nothing leaves its slot empty, so the caller can
+// tell which of its documents were written.
+func TestDocHashEmptyForUnmatchedUpdate(t *testing.T) {
+	ctx, coll := docHashBackend(t)
+
+	_, err := coll.InsertAll(ctx, &backends.InsertAllParams{
+		Docs: []*types.Document{docHashDoc(t, "_id", int64(1), "a", "x")},
+	})
+	require.NoError(t, err)
+
+	upd, err := coll.UpdateAll(ctx, &backends.UpdateAllParams{
+		Docs: []*types.Document{
+			docHashDoc(t, "_id", int64(404), "a", "z"),
+			docHashDoc(t, "_id", int64(1), "a", "y"),
+		},
+		ReturnDocHashes: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), upd.Updated)
+	require.Len(t, upd.DocHashes, 2)
+	require.Empty(t, upd.DocHashes[0])
+	require.NotEmpty(t, upd.DocHashes[1])
+}

--- a/internal/backends/dolt/helpers.go
+++ b/internal/backends/dolt/helpers.go
@@ -240,6 +240,17 @@ func sha512Key(b []byte) [20]byte {
 	return h
 }
 
+// docContentHash addresses a stored document by its content: SHA-512/20 over
+// the canonical stored bytes (bsonFormatVersion followed by lex-sorted BSON),
+// the digest and width dolt uses for chunk addresses. Two documents share a
+// hash iff their stored bytes are identical, on any branch and any server;
+// the hash changes iff the stored bytes change. It is not the address of a
+// chunk: documents under the tuple-builder threshold are stored inline and
+// have no chunk of their own.
+func docContentHash(stored []byte) hash.Hash {
+	return hash.Hash(sha512Key(stored))
+}
+
 func wirebsonIDHash(id any) ([20]byte, error) {
 	doc := wirebson.MakeDocument(1)
 

--- a/internal/handler/common/insert.go
+++ b/internal/handler/common/insert.go
@@ -31,6 +31,11 @@ type InsertParams struct {
 	Collection string       `dumbo:"insert,collection"`
 	Ordered    bool         `dumbo:"ordered,opt"`
 
+	// DumboDocHashes asks for the content hash of every stored document on the
+	// acknowledgment. DumboDB extension, off by default: the reply carries the
+	// MongoDB fields and nothing else unless it is set.
+	DumboDocHashes bool `dumbo:"dumboDocHashes,opt"`
+
 	MaxTimeMS                int64           `dumbo:"maxTimeMS,ignored"`
 	WriteConcern             *types.Document `dumbo:"writeConcern,opt"`
 	BypassDocumentValidation bool            `dumbo:"bypassDocumentValidation,opt"`

--- a/internal/handler/common/update.go
+++ b/internal/handler/common/update.go
@@ -43,6 +43,27 @@ type kvOp struct {
 	Operator string
 }
 
+// appendUpdateDocHashes records one {_id, hash} entry per stored document.
+// hashes runs parallel to docs; an empty entry means the document matched
+// nothing and was not written.
+func appendUpdateDocHashes(result *UpdateResult, hashes []string, docs []*types.Document) {
+	for i, h := range hashes {
+		if i >= len(docs) || h == "" {
+			continue
+		}
+
+		id, err := docs[i].Get("_id")
+		if err != nil {
+			continue
+		}
+
+		result.DocHashes = append(result.DocHashes, must.NotFail(types.NewDocument(
+			"_id", id,
+			"hash", h,
+		)))
+	}
+}
+
 // UpdateDocument iterates through documents from iter and processes them sequentially based on param.
 // Returns UpdateResult if all operations (update/upsert) are successful.
 //
@@ -72,14 +93,20 @@ func UpdateDocument(ctx context.Context, c backends.Collection, cmd string, iter
 		if len(pending) == 0 {
 			return nil
 		}
-		params := &backends.UpdateAllParams{Docs: pending, SkipDurableSync: skipDurableSync}
+		params := &backends.UpdateAllParams{
+			Docs:            pending,
+			SkipDurableSync: skipDurableSync,
+			ReturnDocHashes: param.ReturnDocHashes,
+		}
 		if hasAnyMutations(pendingMutations) {
 			params.FieldMutations = pendingMutations
 		}
-		if _, err := c.UpdateAll(ctx, params); err != nil {
+		res, err := c.UpdateAll(ctx, params)
+		if err != nil {
 			return lazyerrors.Error(err)
 		}
 		result.Modified.Count += int32(len(pending))
+		appendUpdateDocHashes(result, res.DocHashes, pending)
 		pending = nil
 		pendingMutations = nil
 		return nil
@@ -183,10 +210,15 @@ func UpdateDocument(ctx context.Context, c backends.Collection, cmd string, iter
 			if err := flushPending(); err != nil {
 				return nil, err
 			}
-			_, err = c.InsertAll(ctx, &backends.InsertAllParams{Docs: []*types.Document{doc}, SkipDurableSync: skipDurableSync})
-			if err != nil {
-				return nil, lazyerrors.Error(err)
+			insertRes, insertErr := c.InsertAll(ctx, &backends.InsertAllParams{
+				Docs:            []*types.Document{doc},
+				SkipDurableSync: skipDurableSync,
+				ReturnDocHashes: param.ReturnDocHashes,
+			})
+			if insertErr != nil {
+				return nil, lazyerrors.Error(insertErr)
 			}
+			appendUpdateDocHashes(result, insertRes.DocHashes, []*types.Document{doc})
 			result.Upserted.Doc = doc
 
 			// upsert happens only once, no need to iterate further

--- a/internal/handler/common/update_params.go
+++ b/internal/handler/common/update_params.go
@@ -34,6 +34,11 @@ type UpdateParams struct {
 	Comment   string `dumbo:"comment,opt"`
 	MaxTimeMS int64  `dumbo:"maxTimeMS,opt,wholePositiveNumber"`
 
+	// DumboDocHashes asks for the content hash of every stored document on the
+	// acknowledgment. DumboDB extension, off by default: the reply carries the
+	// MongoDB fields and nothing else unless it is set.
+	DumboDocHashes bool `dumbo:"dumboDocHashes,opt"`
+
 	Let *types.Document `dumbo:"let,unimplemented"`
 
 	Ordered                  bool            `dumbo:"ordered,ignored"`
@@ -77,6 +82,10 @@ type Update struct {
 	ValidationLevel  string          `dumbo:"-"`
 	ValidationAction string          `dumbo:"-"`
 
+	// ReturnDocHashes is copied from the command-level DumboDocHashes by the
+	// handler, alongside the validator fields.
+	ReturnDocHashes bool `dumbo:"-"`
+
 	C            *types.Document `dumbo:"c,unimplemented"`
 	Collation    *types.Document `dumbo:"collation,opt"`
 	ArrayFilters *types.Array    `dumbo:"arrayFilters,opt"`
@@ -101,6 +110,10 @@ type UpdateResult struct {
 		Doc   *types.Document
 		Count int32
 	}
+
+	// DocHashes holds one {_id, hash} document per stored document when the
+	// caller set Update.ReturnDocHashes; nil otherwise.
+	DocHashes []*types.Document
 
 	// WarnAllowed counts documents written despite failing the collection
 	// validator because validationAction is "warn".

--- a/internal/handler/msg_insert.go
+++ b/internal/handler/msg_insert.go
@@ -34,6 +34,28 @@ import (
 	"github.com/dolthub/dumbodb/internal/util/must"
 )
 
+// appendDocHashes records one {index, _id, hash} entry per stored document.
+// hashes runs parallel to docs, and idxs gives each document's position in the
+// client's documents array (the index writeErrors reports too).
+func appendDocHashes(out *types.Array, hashes []string, docs []*types.Document, idxs []int) {
+	for i, h := range hashes {
+		if i >= len(docs) || i >= len(idxs) {
+			break
+		}
+
+		id, err := docs[i].Get("_id")
+		if err != nil {
+			continue
+		}
+
+		out.Append(must.NotFail(types.NewDocument(
+			"index", int32(idxs[i]),
+			"_id", id,
+			"hash", h,
+		)))
+	}
+}
+
 func WriteErrorDocument(we *mongo.WriteError) *types.Document {
 	return must.NotFail(types.NewDocument(
 		"index", int32(we.Index),
@@ -110,6 +132,7 @@ func (h *Handler) MsgInsert(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 
 	var inserted int32
 	var writeErrors []*mongo.WriteError
+	docHashes := types.MakeArray(0)
 
 	var done bool
 	for !done {
@@ -227,8 +250,15 @@ func (h *Handler) MsgInsert(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 			docsIndexes = append(docsIndexes, i)
 		}
 
-		if _, err = c.InsertAll(connCtx, &backends.InsertAllParams{Docs: docs, SkipDurableSync: params.SkipDurableSync}); err == nil {
+		var insertRes *backends.InsertAllResult
+
+		if insertRes, err = c.InsertAll(connCtx, &backends.InsertAllParams{
+			Docs:            docs,
+			SkipDurableSync: params.SkipDurableSync,
+			ReturnDocHashes: params.DumboDocHashes,
+		}); err == nil {
 			inserted += int32(len(docs))
+			appendDocHashes(docHashes, insertRes.DocHashes, docs, docsIndexes)
 
 			if params.Ordered && len(writeErrors) > 0 {
 				break
@@ -239,11 +269,13 @@ func (h *Handler) MsgInsert(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 
 		// insert doc one by one upon failing on batch insertion
 		for j, doc := range docs {
-			if _, err = c.InsertAll(connCtx, &backends.InsertAllParams{
+			if insertRes, err = c.InsertAll(connCtx, &backends.InsertAllParams{
 				Docs:            []*types.Document{doc},
 				SkipDurableSync: params.SkipDurableSync,
+				ReturnDocHashes: params.DumboDocHashes,
 			}); err == nil {
 				inserted++
+				appendDocHashes(docHashes, insertRes.DocHashes, []*types.Document{doc}, docsIndexes[j:j+1])
 
 				continue
 			}
@@ -306,6 +338,10 @@ func (h *Handler) MsgInsert(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 		}
 
 		res.Set("writeErrors", array)
+	}
+
+	if params.DumboDocHashes {
+		res.Set("dumboDocHashes", docHashes)
 	}
 
 	res.Set("ok", float64(1))

--- a/internal/handler/msg_update.go
+++ b/internal/handler/msg_update.go
@@ -59,7 +59,7 @@ func (h *Handler) MsgUpdate(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 		defer cancel()
 	}
 
-	matched, modified, upserted, err := h.updateDocument(ctx, params)
+	matched, modified, upserted, docHashes, err := h.updateDocument(ctx, params)
 	if err != nil {
 		if params.MaxTimeMS > 0 && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
 			return nil, handlererrors.NewCommandErrorMsgWithArgument(
@@ -80,6 +80,11 @@ func (h *Handler) MsgUpdate(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 	}
 
 	res.Set("nModified", modified)
+
+	if params.DumboDocHashes {
+		res.Set("dumboDocHashes", docHashes)
+	}
+
 	res.Set("ok", float64(1))
 
 	return documentOpMsg(
@@ -88,25 +93,26 @@ func (h *Handler) MsgUpdate(connCtx context.Context, msg *wire.OpMsg) (*wire.OpM
 }
 
 // updateDocument iterate through all documents in collection and update them.
-func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParams) (int32, int32, *types.Array, error) {
+func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParams) (int32, int32, *types.Array, *types.Array, error) { //nolint:lll // for readability
 	var matched, modified int32
 	var upserted types.Array
+	docHashes := types.MakeArray(0)
 
 	db, err := h.b.Database(params.DB)
 	if err != nil {
 		if backends.ErrorCodeIs(err, backends.ErrorCodeDatabaseNameIsInvalid) {
 			msg := fmt.Sprintf("Invalid namespace specified '%s.%s'", params.DB, params.Collection)
-			return 0, 0, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrInvalidNamespace, msg, "update")
+			return 0, 0, nil, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrInvalidNamespace, msg, "update")
 		}
 
-		return 0, 0, nil, lazyerrors.Error(err)
+		return 0, 0, nil, nil, lazyerrors.Error(err)
 	}
 
 	// Check if collection is a view  -- views don't support write operations.
 	if collRes, collErr := db.ListCollections(ctx, &backends.ListCollectionsParams{Name: params.Collection}); collErr == nil {
 		if len(collRes.Collections) == 1 && collRes.Collections[0].IsView {
 			msg := fmt.Sprintf("namespace '%s.%s' is a view, not a collection", params.DB, params.Collection)
-			return 0, 0, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrCommandNotSupportedOnView, msg, "update")
+			return 0, 0, nil, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrCommandNotSupportedOnView, msg, "update")
 		}
 	}
 
@@ -119,9 +125,9 @@ func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParam
 		// nothing
 	case backends.ErrorCodeIs(err, backends.ErrorCodeCollectionNameIsInvalid):
 		msg := fmt.Sprintf("Invalid collection name: %s", params.Collection)
-		return 0, 0, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrInvalidNamespace, msg, "insert")
+		return 0, 0, nil, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrInvalidNamespace, msg, "insert")
 	default:
-		return 0, 0, nil, lazyerrors.Error(err)
+		return 0, 0, nil, nil, lazyerrors.Error(err)
 	}
 
 	var validator *types.Document
@@ -136,15 +142,16 @@ func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParam
 		if err != nil {
 			if backends.ErrorCodeIs(err, backends.ErrorCodeCollectionNameIsInvalid) {
 				msg := fmt.Sprintf("Invalid collection name: %s", params.Collection)
-				return 0, 0, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrInvalidNamespace, msg, "insert")
+				return 0, 0, nil, nil, handlererrors.NewCommandErrorMsgWithArgument(handlererrors.ErrInvalidNamespace, msg, "insert")
 			}
 
-			return 0, 0, nil, lazyerrors.Error(err)
+			return 0, 0, nil, nil, lazyerrors.Error(err)
 		}
 
 		u.Validator = validator
 		u.ValidationLevel = valLevel
 		u.ValidationAction = valAction
+		u.ReturnDocHashes = params.DumboDocHashes
 
 		cmp := collation.Parse(u.Collation).Comparator()
 
@@ -156,7 +163,7 @@ func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParam
 
 		res, err := c.Query(ctx, &qp)
 		if err != nil {
-			return 0, 0, nil, lazyerrors.Error(err)
+			return 0, 0, nil, nil, lazyerrors.Error(err)
 		}
 
 		closer := iterator.NewMultiCloser()
@@ -173,19 +180,23 @@ func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParam
 		result, err := common.UpdateDocument(ctx, c, "update", iter, &u, params.SkipDurableSync)
 		if err != nil {
 			if backends.ErrorCodeIs(err, backends.ErrorCodeReadOnlyDatabase) {
-				return 0, 0, nil, handlererrors.NewCommandErrorMsg(
+				return 0, 0, nil, nil, handlererrors.NewCommandErrorMsg(
 					handlererrors.ErrOperationFailed,
 					"cannot write to a read-only database snapshot",
 				)
 			}
 			if backends.ErrorCodeIs(err, backends.ErrorCodeWriteConflict) {
-				return 0, 0, nil, common.TranslateBackendWriteError(err)
+				return 0, 0, nil, nil, common.TranslateBackendWriteError(err)
 			}
-			return 0, 0, nil, lazyerrors.Error(err)
+			return 0, 0, nil, nil, lazyerrors.Error(err)
 		}
 
 		matched += result.Matched.Count
 		modified += result.Modified.Count
+
+		for _, entry := range result.DocHashes {
+			docHashes.Append(entry)
+		}
 
 		if result.WarnAllowed > 0 {
 			h.L.Warn("documents allowed despite failing validation (validationAction:warn)",
@@ -204,5 +215,5 @@ func (h *Handler) updateDocument(ctx context.Context, params *common.UpdateParam
 		}
 	}
 
-	return matched, modified, &upserted, nil
+	return matched, modified, &upserted, docHashes, nil
 }

--- a/tests/doc_hash_test.go
+++ b/tests/doc_hash_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// docHashEntries reads the dumboDocHashes array from a write acknowledgment.
+func docHashEntries(t *testing.T, res bson.M) []bson.M {
+	t.Helper()
+
+	raw, ok := res["dumboDocHashes"]
+	require.True(t, ok, "acknowledgment must carry dumboDocHashes: %v", res)
+
+	arr, ok := raw.(bson.A)
+	require.True(t, ok, "dumboDocHashes must be an array, got %T", raw)
+
+	out := make([]bson.M, 0, len(arr))
+	for _, entry := range arr {
+		out = append(out, dmap(entry))
+	}
+	return out
+}
+
+func docHashOf(t *testing.T, entry bson.M) string {
+	t.Helper()
+
+	h, ok := entry["hash"].(string)
+	require.True(t, ok, "entry must carry a string hash, got %T", entry["hash"])
+	require.Len(t, h, 32, "hashes render as 32-character base32, like commit hashes")
+	return h
+}
+
+// insert with dumboDocHashes:true names every stored document and its content
+// hash on the acknowledgment; without the flag the reply is untouched.
+func TestDocHashes_InsertAck(t *testing.T) {
+	env := startDumboDB(t)
+	db := env.Client.Database("testdb")
+	coll := env.Collection(t)
+
+	res := runCommandRaw(t, db, bson.D{
+		{Key: "insert", Value: coll.Name()},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: int32(1)}, {Key: "a", Value: "x"}},
+			bson.D{{Key: "_id", Value: int32(2)}, {Key: "a", Value: "y"}},
+		}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	require.Equal(t, float64(1), res["ok"])
+
+	entries := docHashEntries(t, res)
+	require.Len(t, entries, 2)
+	assert.Equal(t, int32(0), entries[0]["index"])
+	assert.Equal(t, int32(1), entries[0]["_id"])
+	assert.Equal(t, int32(1), entries[1]["index"])
+	assert.Equal(t, int32(2), entries[1]["_id"])
+	assert.NotEqual(t, docHashOf(t, entries[0]), docHashOf(t, entries[1]),
+		"different documents must hash differently")
+
+	plain := runCommandRaw(t, db, bson.D{
+		{Key: "insert", Value: coll.Name()},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: int32(3)}}}},
+	})
+	require.Equal(t, float64(1), plain["ok"])
+	_, present := plain["dumboDocHashes"]
+	assert.False(t, present, "an insert that did not ask must answer exactly as MongoDB does")
+}
+
+// The hash tracks stored content across writes: it moves when a field changes
+// and comes back when the earlier content is written again.
+func TestDocHashes_UpdateAckFollowsContent(t *testing.T) {
+	env := startDumboDB(t)
+	db := env.Client.Database("testdb")
+	coll := env.Collection(t)
+
+	inserted := runCommandRaw(t, db, bson.D{
+		{Key: "insert", Value: coll.Name()},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: int32(1)}, {Key: "a", Value: "x"}}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	original := docHashOf(t, docHashEntries(t, inserted)[0])
+
+	changed := runCommandRaw(t, db, bson.D{
+		{Key: "update", Value: coll.Name()},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "a", Value: "y"}}}}},
+		}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	require.Equal(t, float64(1), changed["ok"])
+
+	entries := docHashEntries(t, changed)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int32(1), entries[0]["_id"])
+	assert.NotEqual(t, original, docHashOf(t, entries[0]), "changed content must change the hash")
+
+	restored := runCommandRaw(t, db, bson.D{
+		{Key: "update", Value: coll.Name()},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "a", Value: "x"}}}}},
+		}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	assert.Equal(t, original, docHashOf(t, docHashEntries(t, restored)[0]),
+		"identical content must hash identically, whatever route wrote it")
+}
+
+// A commit does not touch document content, so the hashes a client holds stay
+// valid across it: document identity is not database version.
+func TestDocHashes_SurviveCommit(t *testing.T) {
+	env := startDumboDB(t)
+	db := env.Client.Database("testdb")
+	coll := env.Collection(t)
+
+	inserted := runCommandRaw(t, db, bson.D{
+		{Key: "insert", Value: coll.Name()},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: int32(1)}, {Key: "a", Value: "x"}}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	original := docHashOf(t, docHashEntries(t, inserted)[0])
+
+	dumboDBCommit(t, env, "testdb", "hold the document")
+
+	// A write that changes nothing stores nothing, so it names no document.
+	noop := runCommandRaw(t, db, bson.D{
+		{Key: "update", Value: coll.Name()},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "a", Value: "x"}}}}},
+		}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	assert.Empty(t, docHashEntries(t, noop), "an update that stores nothing reports nothing")
+
+	runCommandRaw(t, db, bson.D{
+		{Key: "update", Value: coll.Name()},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "a", Value: "y"}}}}},
+		}}},
+	})
+
+	rewritten := runCommandRaw(t, db, bson.D{
+		{Key: "update", Value: coll.Name()},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "a", Value: "x"}}}}},
+		}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	assert.Equal(t, original, docHashOf(t, docHashEntries(t, rewritten)[0]),
+		"a commit between writes must not move a document's hash")
+}
+
+// An upsert stores a document, so it reports one too.
+func TestDocHashes_Upsert(t *testing.T) {
+	env := startDumboDB(t)
+	db := env.Client.Database("testdb")
+	coll := env.Collection(t)
+
+	res := runCommandRaw(t, db, bson.D{
+		{Key: "update", Value: coll.Name()},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: int32(7)}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "a", Value: "x"}}}}},
+			{Key: "upsert", Value: true},
+		}}},
+		{Key: "dumboDocHashes", Value: true},
+	})
+	require.Equal(t, float64(1), res["ok"])
+
+	entries := docHashEntries(t, res)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int32(7), entries[0]["_id"])
+	assert.NotEmpty(t, docHashOf(t, entries[0]))
+}


### PR DESCRIPTION
Clients that maintain caches or live state over documents need per-document
change detection, and today the wire carries none: no write acknowledgment
or read result includes per-document version metadata, so the only shape is
head-query-then-read (`dumboStatus` / `dumboLog {limit: 1}`) — whole-database
granularity, and racy against a concurrent commit.

This PR adds an opt-in: pass `dumboDocHashes: true` on `insert` or `update`,
and the ack carries each written document's content hash. Without the flag,
replies are byte-identical to today — nothing opts in by accident (the
parity harness stays clean).

```
insert ack:  dumboDocHashes: [ { index, _id, hash }, ... ]   // request order
update ack:  dumboDocHashes: [ { _id, hash }, ... ]          // upsert included
```

## Why hash-at-write is the mechanism (what we learned reading the storage)

We first assumed the storage engine already held a per-document address to
surface. It doesn't, for the normal case: the document body is one
adaptive-bytes field, and below `DefaultTupleLengthTarget` (2048) the bytes
live inline in the leaf tuple and never become a chunk
(`val/tuple_builder.go` — only larger documents spill to an addressed blob).
So there is no existing per-document content address to expose, and the
right identity is a hash of the canonical stored bytes —
`[bsonFormatVersion][BSON, keys lex-sorted at every level]` — computed at
the write points where those bytes are already in memory
(`collection.go` insert/update paths). Cost: one digest over an in-memory
buffer; no extra tree read, no extra chunk, no storage change, no
dependency added.

The digest is SHA-512/20 rendered base32 — the same family and width as the
hashes already on the wire — and because the input is the canonical form, a
client can recompute it independently: identical content gives an identical
hash across commits, branches, servers, and restarts.

## Tests

- `internal/backends/dolt/doc_hash_test.go` — backend level: hash present
  and stable, changes iff bytes change, canonical (key order does not
  matter), upsert covered.
- `tests/doc_hash_test.go` — through the wire: flag on/off, insert order,
  update and upsert shapes, reply byte-parity without the flag.

`go test ./... -count=1 -p 1` green (the `-p 1` is for the pre-existing
`.runtime/bin` race between `tests` and `tests/verify`, not this change).

## Try it

```js
// npm i mongodb
// DUMBO_URL=mongodb://127.0.0.1:27017 DUMBO_DB=example node example.mjs
import { MongoClient } from "mongodb";

const client = await new MongoClient(process.env.DUMBO_URL, { directConnection: true }).connect();
const db = client.db(process.env.DUMBO_DB);

const ins = await db.command({
  insert: "docs",
  documents: [{ _id: 1, status: "draft" }, { _id: 2, status: "live" }],
  dumboDocHashes: true,
});
console.log(ins.dumboDocHashes);   // [ { index: 0, _id: 1, hash: "..." }, { index: 1, _id: 2, hash: "..." } ]

const upd = await db.command({
  update: "docs",
  updates: [{ q: { _id: 1 }, u: { $set: { status: "review" } } }],
  dumboDocHashes: true,
});
console.log(upd.dumboDocHashes);   // [ { _id: 1, hash: "..." } ] — different bytes, different hash

// a no-op update returns the SAME hash: the hash is content, not history
```

## Scope, deliberately narrow

`insert`, `update`, upsert. Not covered, and open for discussion before
code: `findAndModify`, `bulkWrite`, reads — and the **merge path**, which
is where we want this most ("which of my thousand held documents did that
merge touch") and where the ack shape deserves agreement first rather than
a guess.

Happy to adjust any of the shape.
